### PR TITLE
support pre-filled databases

### DIFF
--- a/src/@ionic-native/plugins/sqlite/index.ts
+++ b/src/@ionic-native/plugins/sqlite/index.ts
@@ -16,6 +16,10 @@ export interface SQLiteDatabaseConfig {
    * iOS Database Location. Example: 'Library'
    */
   iosDatabaseLocation?: string;
+  /**
+  * support opening pre-filled databases with https://github.com/litehelpers/cordova-sqlite-ext
+  */
+  createFromLocation?: number;
 }
 
 /**


### PR DESCRIPTION
This allows the same plugin wrapper to be used with an alternative version that supports pre-filled sqlite databases.
See https://github.com/litehelpers/cordova-sqlite-ext

Installing sqlite-ext:
```
ionic cordova plugin add cordova-sqlite-ext --save
npm install --save @ionic-native/sqlite

```
Opening an existing database requires the "createFromLocation" param:
```
this.sqlite.create({
      name: dbName,
      location: 'default',
      createFromLocation: 1
    })
```
This patch adds that param as an optional parameter.