### PR TITLE
docs(Toast) template literal in example usage

### DIFF
--- a/src/@ionic-native/plugins/toast/index.ts
+++ b/src/@ionic-native/plugins/toast/index.ts
@@ -51,7 +51,7 @@ export interface ToastOptions {
  *
  * ...
  *
- * this.toast.show('I'm a toast', '5000', 'center').subscribe(
+ * this.toast.show(`I'm a toast`, '5000', 'center').subscribe(
  *   toast => {
  *     console.log(toast);
  *   }


### PR DESCRIPTION
The single quote needed to be escaped to providing proper syntax highlighting in documentation in Usage part of [Toast Docs](http://ionicframework.com/docs/native/toast/)

![screenshot-ionicframework com-2017-07-04-11-29-36](https://user-images.githubusercontent.com/11143604/27816955-4bb70fb6-60ac-11e7-88a8-a9a6d49f316b.png)
