### PR TITLE
refactor(file-transfer): rename to FileTransfer to match original plugin

### DIFF
--- a/src/@ionic-native/plugins/file-transfer/index.ts
+++ b/src/@ionic-native/plugins/file-transfer/index.ts
@@ -1,8 +1,6 @@
 import { Injectable } from '@angular/core';
 import { CordovaInstance, Plugin, InstanceCheck, checkAvailability, IonicNativePlugin } from '@ionic-native/core';
 
-declare const FileTransfer: any;
-
 export interface FileUploadOptions {
 
   /**
@@ -109,21 +107,21 @@ export interface FileTransferError {
 }
 
 /**
- * @name Transfer
+ * @name File Transfer
  *
  * @description
  * This plugin allows you to upload and download files.
  *
  * @usage
  * ```typescript
- * import { Transfer, FileUploadOptions, TransferObject } from '@ionic-native/transfer';
+ * import { FileTransfer, FileUploadOptions, FileTransferObject } from '@ionic-native/transfer';
  * import { File } from '@ionic-native/file';
  *
- * constructor(private transfer: Transfer, private file: File) { }
+ * constructor(private transfer: FileTransfer, private file: File) { }
  *
  * ...
  *
- * const fileTransfer: TransferObject = this.transfer.create();
+ * const fileTransfer: FileTransferObject = this.transfer.create();
  *
  * // Upload a file:
  * fileTransfer.upload(..).then(..).catch(..);
@@ -170,7 +168,7 @@ export interface FileTransferError {
  * FileUploadResult
  * FileTransferError
  * @classes
- * TransferObject
+ * FileTransferObject
  */
 @Plugin({
   pluginName: 'FileTransfer',
@@ -180,7 +178,7 @@ export interface FileTransferError {
   platforms: ['Amazon Fire OS', 'Android', 'Browser', 'iOS', 'Ubuntu', 'Windows', 'Windows Phone']
 })
 @Injectable()
-export class Transfer extends IonicNativePlugin {
+export class FileTransfer extends IonicNativePlugin {
 
   /**
    * Error code rejected from upload with FileTransferError
@@ -202,10 +200,10 @@ export class Transfer extends IonicNativePlugin {
 
   /**
    * Creates a new FileTransfer object
-   * @return {TransferObject}
+   * @return {FileTransferObject}
    */
-  create(): TransferObject {
-    return new TransferObject();
+  create(): FileTransferObject {
+    return new FileTransferObject();
   }
 
 }
@@ -217,12 +215,12 @@ export class Transfer extends IonicNativePlugin {
   plugin: 'cordova-plugin-file-transfer',
   pluginName: 'FileTransfer'
 })
-export class TransferObject {
+export class FileTransferObject {
   private _objectInstance: any;
 
   constructor() {
-    if (checkAvailability('FileTransfer', null, 'FileTransfer') === true) {
-      this._objectInstance = new FileTransfer();
+    if (checkAvailability(FileTransfer.getPluginRef(), null, FileTransfer.getPluginName()) === true) {
+      this._objectInstance = new (FileTransfer.getPlugin())();
     }
   }
 
@@ -239,9 +237,7 @@ export class TransferObject {
     successIndex: 2,
     errorIndex: 3
   })
-  upload(fileUrl: string, url: string, options?: FileUploadOptions, trustAllHosts?: boolean): Promise<FileUploadResult> {
-    return;
-  }
+  upload(fileUrl: string, url: string, options?: FileUploadOptions, trustAllHosts?: boolean): Promise<FileUploadResult> { return; }
 
   /**
    * Downloads a file from server.
@@ -256,9 +252,7 @@ export class TransferObject {
     successIndex: 2,
     errorIndex: 3
   })
-  download(source: string, target: string, trustAllHosts?: boolean, options?: { [s: string]: any; }): Promise<any> {
-    return;
-  }
+  download(source: string, target: string, trustAllHosts?: boolean, options?: { [s: string]: any; }): Promise<any> { return; }
 
   /**
    * Registers a listener that gets called whenever a new chunk of data is transferred.
@@ -276,5 +270,5 @@ export class TransferObject {
   @CordovaInstance({
     sync: true
   })
-  abort(): void { }
+  abort(): void {}
 }


### PR DESCRIPTION
BREAKING CHANGE: Package name is now `@ionic-native/file-transfer`. `Transfer` class has been
renamed to `FileTransfer`. Also, `TransferObject` class has been renamed to `FileTransferObject`.