### PR TITLE
docs(): add paid tag

### DIFF
--- a/scripts/docs/processors/jekyll.js
+++ b/scripts/docs/processors/jekyll.js
@@ -24,6 +24,18 @@ module.exports = function jekyll(renderDocsProcessor) {
           .replace('content/', '');
       });
 
+      const betaDocs = [];
+
+      docs = docs.filter(doc => {
+        if (doc.beta === true) {
+          betaDocs.push(doc);
+          return false;
+        }
+        return true;
+      });
+
+      docs = docs.concat(betaDocs);
+
       // add side menu
       docs.push({
         docType: 'nativeMenu',

--- a/scripts/docs/tag-defs/tag-defs.js
+++ b/scripts/docs/tag-defs/tag-defs.js
@@ -6,5 +6,6 @@ module.exports = [
   {'name': 'usage'},
   {'name': 'hidden'}, // hide from docs
   {'name': 'classes'}, // related classes
-  {'name': 'interfaces'} // related interfaces
+  {'name': 'interfaces'}, // related interfaces
+  {'name': 'paid', transforms: (doc, tag, value) => typeof value !== 'undefined'} // paid plugin, set value to true
 ];

--- a/scripts/docs/templates/common.template.html
+++ b/scripts/docs/templates/common.template.html
@@ -147,6 +147,9 @@ docType: "<$ doc.docType $>"
   <@- if doc.beta == true -@>
     <span class="beta" title="beta">&beta;</span>
   <@- endif -@>
+  <@- if doc.paid == true -@>
+  <span class="paid" title="paid">Paid</span>
+  <@- endif -@>
 </h1>
 
 <a class="improve-v2-docs" href="http://github.com/ionic-team/ionic-native/edit/master/<$ doc.fileInfo.relativePath|replace('/home/ubuntu/ionic-native/', '')|replace('//','/') $>#L<$ doc.location.start.line $>">
@@ -161,6 +164,12 @@ docType: "<$ doc.docType $>"
   This plugin is still in beta stage and may not work as expected. Please
   submit any issues to the <a target="_blank"
   href="<$ prop.repo $>/issues">plugin repo</a>.
+</p>
+<@ endif @>
+<@ if doc.paid == true @>
+<p class="paid-notice">
+  This plugin might require a paid license, or might take a share of your app's earnings.
+  Check the <a target="_blank" rel="nofollow" href="<$ prop.repo $>">plugin's repo</a> for more information.
 </p>
 <@ endif @>
 

--- a/scripts/docs/templates/common.template.html
+++ b/scripts/docs/templates/common.template.html
@@ -148,7 +148,7 @@ docType: "<$ doc.docType $>"
     <span class="beta" title="beta">&beta;</span>
   <@- endif -@>
   <@- if doc.paid == true -@>
-  <span class="paid" title="paid">Paid</span>
+    <span class="paid" title="paid">Paid</span>
   <@- endif -@>
 </h1>
 

--- a/scripts/docs/templates/native_menu.template.html
+++ b/scripts/docs/templates/native_menu.template.html
@@ -4,11 +4,7 @@
 <li class="capitalize {% if page.id == 'mocking' %}active{% endif %}">
   <a href="/docs/native/browser.html">Browser Usage</a>
 </li>
-<@- for doc in docs @><@ if doc.URL and doc.private != true and doc.beta != true @>
+<@- for doc in docs @><@ if doc.URL and doc.private != true @>
 <li class="capitalize {% if page.id == '<$ doc.name|lower|dashify $>' %}active{% endif %}">
-  <a href="/<$ doc.URL $>"><$ doc.name $></a>
-</li><@ endif @><@ endfor @>
-<@- for doc in docs @><@ if doc.URL and doc.private != true and doc.beta == true @>
-<li class="capitalize {% if page.id == '<$ doc.name|lower|dashify $>' %}active{% endif %}">
-  <a href="/<$ doc.URL $>"><$ doc.name $> <span class="beta">&beta;</span></a>
+  <a href="/<$ doc.URL $>"><$ doc.name $></a> <@ if doc.paid == true @><span class="paid">Paid</span><@ endif @><@ if doc.beta == true @><span class="beta">&beta;</span><@ endif @>
 </li><@ endif @><@ endfor @>

--- a/scripts/docs/templates/native_menu.template.html
+++ b/scripts/docs/templates/native_menu.template.html
@@ -6,5 +6,5 @@
 </li>
 <@- for doc in docs @><@ if doc.URL and doc.private != true @>
 <li class="capitalize {% if page.id == '<$ doc.name|lower|dashify $>' %}active{% endif %}">
-  <a href="/<$ doc.URL $>"><$ doc.name $></a> <@ if doc.paid == true @><span class="paid">Paid</span><@ endif @><@ if doc.beta == true @><span class="beta">&beta;</span><@ endif @>
+  <a href="/<$ doc.URL $>"><$ doc.name $><@ if doc.paid == true @> <span class="paid">Paid</span><@ endif @><@ if doc.beta == true @> <span class="beta">&beta;</span><@ endif @></a>
 </li><@ endif @><@ endfor @>

--- a/src/@ionic-native/plugins/admob/index.ts
+++ b/src/@ionic-native/plugins/admob/index.ts
@@ -90,11 +90,11 @@ export interface AdExtras {
 }
 
 /**
+ * @paid
  * @name AdMob
  * @description
  * Plugin for Google Ads, including AdMob / DFP (doubleclick for publisher) and mediations to other Ad networks.
  *
- * IMPORTANT NOTICE: this plugin takes a percentage out of your earnings if you profit more than $1,000. Read more about this on the plugin's repo. For a completely free alternative, see [AdMob Free](../admob-free).
  * @usage
  * ```typescript
  * import { AdMob } from '@ionic-native/admob';

--- a/src/@ionic-native/plugins/native-keyboard/index.ts
+++ b/src/@ionic-native/plugins/native-keyboard/index.ts
@@ -172,12 +172,10 @@ export interface NativeKeyboardUpdateMessengerOptions {
 }
 
 /**
+ * @paid
  * @name Native Keyboard
  * @description
  * A cross platform WhatsApp / Messenger / Slack -style keyboard even. For your Cordova app.
- *
- *
- * IMPORTANT NOTICE: this plugin is paid, please read more about this at the [plugin's repo](https://github.com/EddyVerbruggen/cordova-plugin-native-keyboard#i-like-it-hook-me-up).
  *
  *
  * @usage


### PR DESCRIPTION
Attn. @perrygovier 

This PR changes the following:
- adds a `paid` tag
  - shows a paid label in the menu
  - shows a paid label on the plugin's doc page
  - shows a notice that tells the user that the plugin might require a license or might take shares of profits
- simplified the native menu template, I pushed the beta plugins to the end of the array using JS

Action needed before merging:
Need to add two new CSS styles:
- `span.paid`: used for the label shown in menu & doc page, similar to the beta label
- `p.paid-notice`: used for the paid plugin notice shown on the doc page
