### PR TITLE
Update image-resizer index.ts

### DIFF
--- a/src/@ionic-native/plugins/image-resizer/index.ts
+++ b/src/@ionic-native/plugins/image-resizer/index.ts
@@ -42,11 +42,6 @@ export interface ImageResizerOptions {
  * @description
  * Cordova Plugin For Image Resize
  *
- * Requires plugin `info.protonet.imageresizer` - use the Ionic CLI and type in the following command:
- * `ionic cordova plugin add info.protonet.imageresizer`
- *
- * For more info, please see the https://github.com/protonet/cordova-plugin-image-resizer
- *
  * @usage
  * ```typescript
  * import { ImageResizer, ImageResizerOptions } from '@ionic-native/image-resizer';
@@ -74,9 +69,9 @@ export interface ImageResizerOptions {
  */
 @Plugin({
   pluginName: 'ImageResizer',
-  plugin: 'https://github.com/protonet/cordova-plugin-image-resizer.git',
+  plugin: 'info.protonet.imageresizer',
   pluginRef: 'ImageResizer',
-  repo: 'https://github.com/protonet/cordova-plugin-image-resizer',
+  repo: 'https://github.com/JoschkaSchulz/cordova-plugin-image-resizer',
   platforms: ['Android', 'iOS', 'Windows']
 })
 @Injectable()

--- a/src/@ionic-native/plugins/image-resizer/index.ts
+++ b/src/@ionic-native/plugins/image-resizer/index.ts
@@ -43,7 +43,7 @@ export interface ImageResizerOptions {
  * Cordova Plugin For Image Resize
  *
  * Requires plugin `info.protonet.imageresizer` - use the Ionic CLI and type in the following command:
- * `ionic cordova plugin add https://github.com/protonet/cordova-plugin-image-resizer.git`
+ * `ionic cordova plugin add info.protonet.imageresizer`
  *
  * For more info, please see the https://github.com/protonet/cordova-plugin-image-resizer
  *


### PR DESCRIPTION
Running original command "ionic cordova plugin add https://github.com/protonet/cordova-plugin-image-resizer.git" will throw a Cordova error shown below. Installing the plugin via the plugin cordova id (per the original repo's package.json) will allow this plugin to install correctly and work with the ionic native "image-resizer"

An error occurred while running ionic cordova plugin add https://github.com/protonet/cordova-plugin-image-resizer.git
... (exit code 1):
Error: Failed to fetch plugin https://github.com/protonet/cordova-plugin-image-resizer.git via registry
...