### PR TITLE
Escape < and > from plugin install command in doc template

### DIFF
--- a/scripts/docs/templates/common.template.html
+++ b/scripts/docs/templates/common.template.html
@@ -177,7 +177,7 @@ docType: "<$ doc.docType $>"
 <h2><a class="anchor" name="installation" href="#installation"></a>Installation</h2>
 <ol class="installation">
   <li>Install the Cordova and Ionic Native plugins:<br>
-    <pre><code class="nohighlight">$ <@ if prop.install @><$ prop.install $><@ else @>ionic cordova plugin add <$ prop.plugin $><@ endif @>
+    <pre><code class="nohighlight">$ <@ if prop.install @><$ prop.install | replace('<', '&lt;').replace('>', '&gt;') $><@ else @>ionic cordova plugin add <$ prop.plugin $><@ endif @>
 $ npm install --save @ionic-native/<$ doc.npmId $>
 </code></pre>
   </li>

--- a/src/@ionic-native/plugins/in-app-purchase-2/index.ts
+++ b/src/@ionic-native/plugins/in-app-purchase-2/index.ts
@@ -13,7 +13,8 @@ import { Injectable } from '@angular/core';
  * constructor(private store: InAppPurchase2) { }
  *
  * ...
- * 
+ * ```
+ *
  *  * @advanced
  * 
  *  ```typescript


### PR DESCRIPTION
This was causing an issue on http://ionicframework.com/docs/native/in-app-purchase-2/ where the command `ionic cordova plugin add cc.fovea.cordova.purchase --variable BILLING_KEY="<ANDROID_BILLING_KEY>"` was being interpreted as HTML and not allowing the code block to close.  This escapes those characters.