### PR TITLE
Added ASSUME_GS1 parameter

### DIFF
--- a/src/@ionic-native/plugins/barcode-scanner/index.ts
+++ b/src/@ionic-native/plugins/barcode-scanner/index.ts
@@ -52,7 +52,7 @@ export interface BarcodeScannerOptions {
    * Display scanned text for X ms. 0 suppresses it entirely, default 1500. Supported on Android only.
    */
   resultDisplayDuration?: number;
-  
+
   /*
   * Active proper FNC detection for GS1 Barcodes
   */

--- a/src/@ionic-native/plugins/barcode-scanner/index.ts
+++ b/src/@ionic-native/plugins/barcode-scanner/index.ts
@@ -52,7 +52,12 @@ export interface BarcodeScannerOptions {
    * Display scanned text for X ms. 0 suppresses it entirely, default 1500. Supported on Android only.
    */
   resultDisplayDuration?: number;
-
+  
+  /*
+  * Active proper FNC detection for GS1 Barcodes
+  */
+  ASSUME_GS1?: boolean;
+  
 }
 
 export interface BarcodeScanResult {

--- a/src/@ionic-native/plugins/barcode-scanner/index.ts
+++ b/src/@ionic-native/plugins/barcode-scanner/index.ts
@@ -57,7 +57,6 @@ export interface BarcodeScannerOptions {
   * Active proper FNC detection for GS1 Barcodes
   */
   ASSUME_GS1?: boolean;
-  
 }
 
 export interface BarcodeScanResult {


### PR DESCRIPTION
Added ASSUME_GS1 to active proper FNC detection (Application Identifier with variable field length) is GS1 Barcodes