### PR TITLE
Incorrect Installation Instructions in Docs

### DIFF
--- a/src/@ionic-native/plugins/phonegap-local-notification/index.ts
+++ b/src/@ionic-native/plugins/phonegap-local-notification/index.ts
@@ -87,7 +87,7 @@ export interface LocalNotificationOptions {
  */
 @Plugin({
   pluginName: 'Phonegap Local Notifications',
-  plugin: 'phonegap-local-notifications',
+  plugin: 'phonegap-plugin-local-notification',
   pluginRef: 'Notification',
   repo: 'https://github.com/phonegap/phonegap-plugin-local-notification',
   platforms: ['Android', 'Browser', 'iOS', 'Windows']


### PR DESCRIPTION
$ ionic cordova plugin add phonegap-local-notifications -- should be -- 
$ ionic cordova plugin add phonegap-plugin-local-notification -- in Docs --