### PR TITLE
Fix errors on ionic google maps docs

### DIFF
--- a/src/@ionic-native/plugins/google-maps/index.ts
+++ b/src/@ionic-native/plugins/google-maps/index.ts
@@ -341,39 +341,40 @@ export const GoogleMapsMapTypeId: { [mapType: string]: MapType; } = {
  *  let map: GoogleMap = this.googleMaps.create(element);
  *
  *  // listen to MAP_READY event
- *  // You must wait for this event to fire before adding something to the map or modifying it in anyway
+ *  // You MUST wait for this event be fired before do anything with the map
+ *  // otherwise the application may close unexpectedly.
  *  map.one(GoogleMapsEvent.MAP_READY).then(
  *    () => {
  *      console.log('Map is ready!');
  *      // Now you can add elements to the map like the marker
+ *
+ *      // create LatLng object
+ *      let ionic: LatLng = new LatLng(43.0741904,-89.3809802);
+ *
+ *      // create CameraPosition
+ *      let position: CameraPosition = {
+ *        target: ionic,
+ *        zoom: 18,
+ *        tilt: 30
+ *      };
+ *
+ *      // move the map's camera to position
+ *      map.moveCamera(position);
+ *
+ *      // create new marker
+ *      let markerOptions: MarkerOptions = {
+ *        position: ionic,
+ *        title: 'Ionic'
+ *      };
+ *
+ *      // Add a Map Marker
+ *      map.addMarker(markerOptions)
+ *        .then((marker: Marker) => {
+ *           marker.showInfoWindow();
+ *         });
+ *      }
  *    }
  *  );
- *
- *  // create LatLng object
- *  let ionic: LatLng = new LatLng(43.0741904,-89.3809802);
- *
- *  // create CameraPosition
- *  let position: CameraPosition = {
- *    target: ionic,
- *    zoom: 18,
- *    tilt: 30
- *  };
- *
- *  // move the map's camera to position
- *  map.moveCamera(position);
- *
- *  // create new marker
- *  let markerOptions: MarkerOptions = {
- *    position: ionic,
- *    title: 'Ionic'
- *  };
- *
- *  const marker: Marker = map.addMarker(markerOptions)
- *    .then((marker: Marker) => {
- *       marker.showInfoWindow();
- *     });
- *  }
- *
  * }
  * ```
  * @classes


### PR DESCRIPTION
I've spent hours trying to just add and google map on my application, and always the application was closing with the exact same example of docs.

The problem is that the example is incoherent: It says that you must wait the map ready event prior to do anything with the map, but the example itself do the opposite.

I've updated the docs to put the code in the right place, inside the event listener callback.

Also I've removed the let `const marker: Marker` piece, since `map.addMarker()` method returns a `Promise<Marker>`, not a `Marker`, so the code also fails.

This kind of incoherence on Ionic docs make many developers crazy and about stop using the platform, so you guys should take care about it, **put docs in first place**!