### PR TITLE
Updating googlemaps documentation

### DIFF
--- a/src/@ionic-native/plugins/google-maps/index.ts
+++ b/src/@ionic-native/plugins/google-maps/index.ts
@@ -373,14 +373,16 @@ export const GoogleMapsMapTypeId: { [mapType: string]: MapType; } = {
  *  MarkerOptions,
  *  Marker
  * } from '@ionic-native/google-maps';
+ * import { Platform } 'ionic-angular'
  *
  * export class MapPage {
- *  constructor(private googleMaps: GoogleMaps) {}
+ *  constructor(private googleMaps: GoogleMaps, platform: Platform) {
+ * // Load the map when the platform is ready
+ *    this.platform.ready().then(() => {
+ *      this.loadMap();
+ *    });
+ *  }
  *
- * // Load map only after view is initialized
- * ngAfterViewInit() {
- *  this.loadMap();
- * }
  *
  * loadMap() {
  *  // make sure to create following structure in your view.html file


### PR DESCRIPTION
Since the new googlemaps plugin uses the native code, you need to wait for the platform to be ready before loading the map. If you try to create a maps page using the instructions currently on https://ionicframework.com/docs/native/google-maps/ your map will not render. 