### PR TITLE
docs(nfc): update usage doc of the nfc plugin

### DIFF
--- a/src/@ionic-native/plugins/android-permissions/index.ts
+++ b/src/@ionic-native/plugins/android-permissions/index.ts
@@ -19,7 +19,7 @@ import { Injectable } from '@angular/core';
  *
  * this.androidPermissions.checkPermission(this.androidPermissions.PERMISSION.CAMERA).then(
  *   success => console.log('Permission granted'),
- *   err => this.androidPermissions.requestPermissions(this.androidPermissions.PERMISSION.CAMERA)
+ *   err => this.androidPermissions.requestPermission(this.androidPermissions.PERMISSION.CAMERA)
  * );
  *
  * this.androidPermissions.requestPermissions([this.androidPermissions.PERMISSION.CAMERA, this.androidPermissions.PERMISSION.GET_ACCOUNTS]);

--- a/src/@ionic-native/plugins/nfc/index.ts
+++ b/src/@ionic-native/plugins/nfc/index.ts
@@ -23,8 +23,17 @@ declare let window: any;
  *
  * ...
  *
- * let message = this.ndef.textRecord('Hello world');
- * this.nfc.share([message]).then(onSuccess).catch(onError);
+ * this.nfc.addNdefListener(() => {
+ *   console.log('successfully attached ndef listener');
+ * }, (err) => {
+ *   console.log('error attaching ndef listener', err);
+ * }).subscribe((event) => {
+ *   console.log('received ndef message. the tag contains: ', event.tag);
+ *   console.log('decoded tag id', this.nfc.bytesToHexString(event.tag.id));
+ *
+ *   let message = this.ndef.textRecord('Hello world');
+ *   this.nfc.share([message]).then(onSuccess).catch(onError);
+ * });
  *
  * ```
  */


### PR DESCRIPTION
show an example of how the event listeners work with observable subscription and implement an nfc share within the event listener.