### PR TITLE
Browser Push notification support

### DIFF
--- a/src/@ionic-native/plugins/push/index.ts
+++ b/src/@ionic-native/plugins/push/index.ts
@@ -188,10 +188,25 @@ export interface AndroidPushOptions {
   topics?: string[];
 }
 
+export interface BrowserPushOptions {
+  /**
+   * Optional. Your GCM API key if you are using VAPID keys.
+   */
+  applicationServerKey: string;
+
+  /**
+   * URL for the push server you want to use.
+   * Default: http://push.api.phonegap.com/v1/push	Optional. 
+   */
+  pushServiceURL?: string;
+
+}
+
 export interface PushOptions {
   ios?: IOSPushOptions;
   android?: AndroidPushOptions;
   windows?: any;
+  browser?: BrowserPushOptions;
 }
 
 export type PushEvent = 'registration' | 'error' | 'notification';
@@ -237,7 +252,10 @@ export type PushEvent = 'registration' | 'error' | 'notification';
  *        badge: true,
  *        sound: 'false'
  *    },
- *    windows: {}
+ *    windows: {},
+ *    browser: {
+ *        pushServiceURL: 'http://push.api.phonegap.com/v1/push'
+ *    }
  * };
  *
  * const pushObject: PushObject = this.push.init(options);
@@ -257,6 +275,7 @@ export type PushEvent = 'registration' | 'error' | 'notification';
  * NotificationEventAdditionalData
  * IOSPushOptions
  * AndroidPushOptions
+ * BrowserPushOptions
  * PushOptions
  */
 @Plugin({

--- a/src/@ionic-native/plugins/push/index.ts
+++ b/src/@ionic-native/plugins/push/index.ts
@@ -192,7 +192,7 @@ export interface BrowserPushOptions {
   /**
    * Optional. Your GCM API key if you are using VAPID keys.
    */
-  applicationServerKey: string;
+  applicationServerKey?: string;
 
   /**
    * URL for the push server you want to use.


### PR DESCRIPTION
Browser Push interface with options to use push notification with browsers , as a proxy to phonegap-plush-plugin.

Based on the official docs for `phonegap-plugin-push`:

* https://github.com/phonegap/phonegap-plugin-push/blob/master/docs/API.md#browser

I guess this is what we need to achieve this issue:

* https://github.com/ionic-team/ionic-native/issues/1847

