### PR TITLE
Update pluginRef

### DIFF
--- a/src/@ionic-native/plugins/spinner-dialog/index.ts
+++ b/src/@ionic-native/plugins/spinner-dialog/index.ts
@@ -29,7 +29,7 @@ export interface SpinnerDialogIOSOptions {
 @Plugin({
   pluginName: 'SpinnerDialog',
   plugin: 'cordova-plugin-native-spinner',
-  pluginRef: 'window.plugins.spinnerDialog',
+  pluginRef: 'SpinnerDialog',
   repo: 'https://github.com/greybax/cordova-plugin-native-spinner',
   platforms: ['Android', 'iOS', 'Windows Phone 8', 'Windows']
 })


### PR DESCRIPTION
Wrong pluginRef causes errors:
_Native: tried calling SpinnerDialog.show, but the SpinnerDialog plugin is not installed.
Install the SpinnerDialog plugin: 'ionic cordova plugin add cordova-plugin-native-spinner'_

Fix pluginRef to work properly.