### PR TITLE
docs(navigation): add trailing slash to navigation items

### DIFF
--- a/scripts/docs/processors/jekyll.js
+++ b/scripts/docs/processors/jekyll.js
@@ -22,7 +22,10 @@ module.exports = function jekyll(renderDocsProcessor) {
         doc.URL = doc.outputPath.replace('docs//', 'docs/')
           .replace('/index.md', '')
           .replace('content/', '');
-        doc.URL = doc.URL+'/'; // add trailing slash
+        // add trailing slash to plugin pages
+        if(!doc.URL.endsWith("/") && !doc.URL.endsWith(".html")) {
+          doc.URL = doc.URL+'/'; 
+        }
       });
 
       const betaDocs = [];

--- a/scripts/docs/processors/jekyll.js
+++ b/scripts/docs/processors/jekyll.js
@@ -22,6 +22,7 @@ module.exports = function jekyll(renderDocsProcessor) {
         doc.URL = doc.outputPath.replace('docs//', 'docs/')
           .replace('/index.md', '')
           .replace('content/', '');
+        doc.URL = doc.URL+'/'; // add trailing slash
       });
 
       const betaDocs = [];


### PR DESCRIPTION
fixes the problem that each navigation item first has to redirected to the version with trailing slash

closes https://github.com/ionic-team/ionic-site/issues/1223