### PR TITLE
Adding missing `PayeeEmail` in PayPal plugin

### DIFF
--- a/src/@ionic-native/plugins/paypal/index.ts
+++ b/src/@ionic-native/plugins/paypal/index.ts
@@ -167,22 +167,22 @@ export class PayPalPayment {
    * The amount of the payment.
    */
   amount: string;
-  
+
   /**
    * The ISO 4217 currency for the payment.
    */
   currency: string;
-  
+
   /**
    * A short description of the payment.
    */
   shortDescription: string;
-  
+
   /**
    * "Sale" for an immediate payment.
    */
   intent: string;
-  
+
   /**
    * Optional Build Notation code ("BN code"), obtained from partnerprogram@paypal.com,
    * for your tracking purposes.
@@ -208,12 +208,12 @@ export class PayPalPayment {
    * Optional array of PayPalItem objects.
    */
   items: Array<PayPalItem>;
-  
+
   /**
   * Optional payee email, if your app is paying a third-party merchant.
   */
   payeeEmail: string;
-  
+
   /**
    * Optional customer shipping address, if your app wishes to provide this to the SDK.
    */

--- a/src/@ionic-native/plugins/paypal/index.ts
+++ b/src/@ionic-native/plugins/paypal/index.ts
@@ -167,23 +167,28 @@ export class PayPalPayment {
    * The amount of the payment.
    */
   amount: string;
+  
   /**
    * The ISO 4217 currency for the payment.
    */
   currency: string;
+  
   /**
    * A short description of the payment.
    */
   shortDescription: string;
+  
   /**
    * "Sale" for an immediate payment.
    */
   intent: string;
+  
   /**
    * Optional Build Notation code ("BN code"), obtained from partnerprogram@paypal.com,
    * for your tracking purposes.
    */
   bnCode: string = 'PhoneGap_SP';
+
   /**
    * Optional invoice number, for your tracking purposes. (up to 256 characters)
    */
@@ -203,7 +208,12 @@ export class PayPalPayment {
    * Optional array of PayPalItem objects.
    */
   items: Array<PayPalItem>;
-
+  
+  /**
+  * Optional payee email, if your app is paying a third-party merchant.
+  */
+  payeeEmail: string;
+  
   /**
    * Optional customer shipping address, if your app wishes to provide this to the SDK.
    */


### PR DESCRIPTION
- Available since [v3.5.0 release](https://github.com/paypal/PayPal-Cordova-Plugin/releases/tag/3.5.0)