### PR TITLE
 Geofence plugin method not working maybe duplicate entry with one typo.

### DIFF
--- a/src/@ionic-native/plugins/geofence/index.ts
+++ b/src/@ionic-native/plugins/geofence/index.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { Cordova, Plugin, CordovaFunctionOverride, IonicNativePlugin } from '@ionic-native/core';
+import { Cordova, Plugin, IonicNativePlugin } from '@ionic-native/core';
 import { Observable } from 'rxjs/Observable';
 
 declare const window: any;

--- a/src/@ionic-native/plugins/geofence/index.ts
+++ b/src/@ionic-native/plugins/geofence/index.ts
@@ -90,14 +90,7 @@ export class Geofence extends IonicNativePlugin {
     EXIT: 2,
     BOTH: 3
   };
-
-  /**
-   * Subscribe to get notified when a transition is received
-   * @return {Observable<any>}
-   */
-  @CordovaFunctionOverride()
-  onTrasitionReceived(): Observable<any> { return; };
-
+ 
   /**
    * Initializes the plugin. User will be prompted to allow the app to use location and notifications.
    *


### PR DESCRIPTION
I not sure but in Geofence plugin, when i call the method onTrasitionReceived() the ionic says the plugin is not installed, and it crash. exist other method with 'n' onTransitionReceived but it's working! in the doc's this is very confuse i spend more than a houre to discover this mess. I not sure why this method is there but if not return nothing maybe it's better removing this. Sorry for the english! :-)  