### PR TITLE
supported platforms

### DIFF
--- a/src/@ionic-native/plugins/clipboard/index.ts
+++ b/src/@ionic-native/plugins/clipboard/index.ts
@@ -32,7 +32,7 @@ import { Cordova, Plugin, IonicNativePlugin } from '@ionic-native/core';
   plugin: 'cordova-clipboard',
   pluginRef: 'cordova.plugins.clipboard',
   repo: 'https://github.com/ihadeed/cordova-clipboard',
-  platforms: ['Android', 'iOS', 'Windows', 'Windows Phone 8']
+  platforms: ['Android', 'iOS', 'Windows Phone 8']
 })
 @Injectable()
 export class Clipboard extends IonicNativePlugin {


### PR DESCRIPTION
Removing browser from the list of supported platforms.

Browser being listed in the supported platforms is conflicting with the data in plugin git repo.