### PR TITLE
Update index.ts

### DIFF
--- a/src/@ionic-native/plugins/market/index.ts
+++ b/src/@ionic-native/plugins/market/index.ts
@@ -19,8 +19,8 @@ import { Plugin, Cordova, IonicNativePlugin } from '@ionic-native/core';
  */
 @Plugin({
   pluginName: 'Market',
-  plugin: 'cordova-plugin-market',
-  pluginRef: 'cordova.plugins.market',
+  plugin: 'https://github.com/xmartlabs/cordova-plugin-market',
+  pluginRef: 'https://github.com/xmartlabs/cordova-plugin-market',
   repo: 'https://github.com/xmartlabs/cordova-plugin-market',
   platforms: ['Android', 'iOS']
 })


### PR DESCRIPTION
If you 'ionic cordova plugin add cordova-plugin-market' you get a 404; I'm guessing both plugin and pluginRef should be https://github.com/xmartlabs/cordova-plugin-market, as shown on the repo readme (which definitely works)