### PR TITLE
add optional key parameter to SQLiteDatabaseConfig to support sqlcipher-adapter

### DIFF
--- a/src/@ionic-native/plugins/sqlite/index.ts
+++ b/src/@ionic-native/plugins/sqlite/index.ts
@@ -20,6 +20,10 @@ export interface SQLiteDatabaseConfig {
   * support opening pre-filled databases with https://github.com/litehelpers/cordova-sqlite-ext
   */
   createFromLocation?: number;
+  /**
+   * support encrypted databases with https://github.com/litehelpers/Cordova-sqlcipher-adapter
+   */
+  key?: string;
 }
 
 /**


### PR DESCRIPTION
As described in [this forum thread](https://forum.ionicframework.com/t/execution-failed-for-task-processdebugresources-ionic-compile/103001), users of [cordova-sqlitecipher-adapter](https://github.com/litehelpers/Cordova-sqlcipher-adapter) will encounter type errors when adding their needed encryption key to `SQLite.create()` calls. This PR adds it as an optional parameter.