### PR TITLE
Zeroconf: Incomplete spec - Action can also be `resolved`

### DIFF
--- a/src/@ionic-native/plugins/zeroconf/index.ts
+++ b/src/@ionic-native/plugins/zeroconf/index.ts
@@ -14,7 +14,7 @@ export interface ZeroconfService {
 }
 
 export interface ZeroconfResult {
-  action: 'registered' | 'added' | 'removed';
+  action: 'registered' | 'added' | 'removed' | 'resolved';
   service: ZeroconfService;
 }
 


### PR DESCRIPTION
Hi!

The `ZeroconfResult` interface spec is incomplete. The `action` property can also have the `resolved` value.
