### PR TITLE
Fixed success & error index for launch-navigator.navigate

### DIFF
--- a/src/@ionic-native/plugins/launch-navigator/index.ts
+++ b/src/@ionic-native/plugins/launch-navigator/index.ts
@@ -313,8 +313,8 @@ export class LaunchNavigator extends IonicNativePlugin {
    * @returns {Promise<any>}
    */
   @Cordova({
-    successIndex: 1,
-    errorIndex: 2
+    successIndex: 2,
+    errorIndex: 3
   })
   navigate(destination: string | number[], options?: LaunchNavigatorOptions): Promise<any> { return; }
 


### PR DESCRIPTION
Fixes an issue with the latest launch-navigator plugin (v4). Plugin expects options to be second parameter passed into method `navigate` but ionic-native wrapper was setting the success callback as the second input parameter.