### PR TITLE
Update Documentation

### DIFF
--- a/src/@ionic-native/plugins/http/index.ts
+++ b/src/@ionic-native/plugins/http/index.ts
@@ -1,3 +1,5 @@
+//UPDATE DOCS
+
 import { Injectable } from '@angular/core';
 import { Plugin, Cordova, IonicNativePlugin } from '@ionic-native/core';
 


### PR DESCRIPTION
Installing cordova-plugin-advanced-http as directed by the docs causes the app the throw a "plugin_not_installed" error. However, installing cordova-plugin-http works perfectly with ionic native. Please update the docs so save some other developer the pain of learning this the hard way.