### PR TITLE
Extended the ZeroconfResult.action definition

### DIFF
--- a/src/@ionic-native/plugins/zeroconf/index.ts
+++ b/src/@ionic-native/plugins/zeroconf/index.ts
@@ -14,7 +14,7 @@ export interface ZeroconfService {
 }
 
 export interface ZeroconfResult {
-  action: 'registered' | 'added' | 'removed';
+  action: 'registered' | 'added' | 'removed' | 'resolved';
   service: ZeroconfService;
 }
 


### PR DESCRIPTION
This now includes the value 'resolved', as it is a valid action passed by the service browser on iOS (at least) when IP addresses for the chosen service have been resolved.

This allows people to simplify the process of capturing services with resolved IP addresses.