### PR TITLE
Update documentation for a installation variable

### DIFF
--- a/src/@ionic-native/plugins/geolocation/index.ts
+++ b/src/@ionic-native/plugins/geolocation/index.ts
@@ -153,6 +153,8 @@ export interface GeolocationOptions {
   plugin: 'cordova-plugin-geolocation',
   pluginRef: 'navigator.geolocation',
   repo: 'https://github.com/apache/cordova-plugin-geolocation',
+  install: 'ionic cordova plugin add cordova-plugin-geolocation --variable GEOLOCATION_USAGE_DESCRIPTION="To locate you"',
+  installVariables: ['GEOLOCATION_USAGE_DESCRIPTION'],
   platforms: ['Amazon Fire OS', 'Android', 'BlackBerry 10', 'Browser', 'Firefox OS', 'iOS', 'Ubuntu', 'Windows', 'Windows Phone']
 })
 @Injectable()


### PR DESCRIPTION
Hello guys,

I make this pull request to add the installation variable `GEOLOCATION_USAGE_DESCRIPTION` needed on iOS, since version 10.

Without this variable, using `getCurrentPosition` do nothing on iOS because phone wait user authorization. But that authorization is not display because there is no message defined.

This variable make this part of code in `info.plist` : 

```
<key>NSLocationWhenInUseUsageDescription</key>
<string>To allow locate you</string>
``` 

Source : https://github.com/apache/cordova-plugin-geolocation#ios-quirks

Have a good coding day :)