### PR TITLE
update return value in hasPermission()

### DIFF
--- a/src/@ionic-native/plugins/firebase/index.ts
+++ b/src/@ionic-native/plugins/firebase/index.ts
@@ -71,10 +71,10 @@ export class Firebase extends IonicNativePlugin {
 
   /**
  * Check permission to receive push notifications
- * @return {Promise<any>}
+ * @return {Promise<{isEnabled: boolean}>}
  */
   @Cordova()
-  hasPermission(): Promise<any> { return; }
+  hasPermission(): Promise<{isEnabled: boolean}> { return; }
 
   /**
    * Set icon badge number. Set to 0 to clear the badge.


### PR DESCRIPTION
The return value of the hasPermission() promise is set to return any, but really returns an object that returns with an isEnabled flag