### PR TITLE
refactor(three-dee-touch) Use CordovaFunctionOverride decorator

### DIFF
--- a/src/@ionic-native/plugins/three-dee-touch/index.ts
+++ b/src/@ionic-native/plugins/three-dee-touch/index.ts
@@ -1,9 +1,6 @@
 import { Injectable } from '@angular/core';
-import { Cordova, Plugin, IonicNativePlugin } from '@ionic-native/core';
+import { Cordova, CordovaFunctionOverride, Plugin, IonicNativePlugin } from '@ionic-native/core';
 import { Observable } from 'rxjs/Observable';
-
-
-declare var window: any;
 
 export interface ThreeDeeTouchQuickAction {
 
@@ -165,16 +162,8 @@ export class ThreeDeeTouch extends IonicNativePlugin {
    * When a home icon is pressed, your app launches and this JS callback is invoked.
    * @returns {Observable<any>} returns an observable that notifies you when he user presses on the home screen icon
    */
-  onHomeIconPressed(): Observable<any> {
-    return new Observable(observer => {
-      if (window.ThreeDeeTouch) {
-        window.ThreeDeeTouch.onHomeIconPressed = observer.next.bind(observer);
-      } else {
-        observer.error('3dTouch plugin is not available.');
-        observer.complete();
-      }
-    });
-  }
+  @CordovaFunctionOverride()
+  onHomeIconPressed(): Observable<any> { return; }
 
   /**
    * Enable Link Preview.


### PR DESCRIPTION
The `onHomeIconPressed` function now also uses the `CordovaFunctionOverride` decorator like suggested in #2006.