### PR TITLE
Add senderID to AndroidPushOptions

### DIFF
--- a/src/@ionic-native/plugins/push/index.ts
+++ b/src/@ionic-native/plugins/push/index.ts
@@ -132,6 +132,11 @@ export interface CategoryActionData {
 
 export interface AndroidPushOptions {
   /**
+   * Maps to the project number in the Google Developer Console.
+   */
+  senderID: string;
+
+  /**
    * The name of a drawable resource to use as the small-icon. The name should
    * not include the extension.
    */


### PR DESCRIPTION
phonegap-plugin-push requires `senderID` as an Android option. This change allows TypeScript to acknowledge this parameter and enforce this requirement.

Type definition here: https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/phonegap-plugin-push/index.d.ts#L129