### PR TITLE
feat(push) add support for version 2.1.0

### DIFF
--- a/src/@ionic-native/plugins/push/index.ts
+++ b/src/@ionic-native/plugins/push/index.ts
@@ -208,7 +208,15 @@ export interface PushOptions {
   browser?: BrowserPushOptions;
 }
 
-export type PushEvent = 'registration' | 'error' | 'notification';
+export type Priority = 1 | 2 | 3 | 4 | 5;
+
+export interface Channel {
+  id: string;
+  description: string;
+  importance: Priority;
+}
+
+export type PushEvent = string;
 
 /**
  * @name Push
@@ -240,6 +248,20 @@ export type PushEvent = 'registration' | 'error' | 'notification';
  *
  *   });
  *
+ * // Create a channel (Android O and above). You'll need to provide the id, description and importance properties.
+ * this.push.createChannel({
+ *  id: "testchannel1",
+ *  description: "My first test channel",
+ *  // The importance property goes from 1 = Lowest, 2 = Low, 3 = Normal, 4 = High and 5 = Highest.
+ *  importance: 3
+ * }).then(() => console.log('Channel created'));
+ *
+ * // Delete a channel (Android O and above)
+ * this.push.deleteChannel('testchannel1').then(() => console.log('Channel deleted));
+ *
+ * // Return a list of currently configured channels
+ * this.push.listChannels().then((channels) => console.log('List of channels', channels))
+ *
  * // to initialize push notifications
  *
  * const options: PushOptions = {
@@ -256,6 +278,7 @@ export type PushEvent = 'registration' | 'error' | 'notification';
  * };
  *
  * const pushObject: PushObject = this.push.init(options);
+ *
  *
  * pushObject.on('notification').subscribe((notification: any) => console.log('Received a notification', notification));
  *
@@ -301,6 +324,27 @@ export class Push extends IonicNativePlugin {
    */
   @Cordova()
   hasPermission(): Promise<{ isEnabled: boolean }> { return; }
+
+  /**
+   * Create a new notification channel for Android O and above.
+   * @param channel {Channel}
+   */
+  @Cordova()
+  createChannel(channel: Channel): Promise<any> { return; }
+
+  /**
+   * Delete a notification channel for Android O and above.
+   * @param id
+   */
+  @Cordova()
+  deleteChannel(id: string): Promise<any> { return; }
+
+  /**
+   * Returns a list of currently configured channels.
+   * @return {Promise<Channel[]>}
+   */
+  @Cordova()
+  listChannels(): Promise<Channel[]> { return; }
 
 }
 
@@ -365,9 +409,10 @@ export class PushObject {
    * iOS only
    * Tells the OS that you are done processing a background push notification.
    * successHandler gets called when background push processing is successfully completed.
+   * @param id
    */
   @CordovaInstance()
-  finish(): Promise<any> { return; }
+  finish(id?: string): Promise<any> { return; }
 
   /**
    * Tells the OS to clear all notifications from the Notification Center


### PR DESCRIPTION
This commit adds support for the following methods:
- createChannel
- deleteChannel
- listChannels

Also, I modified the PushEvent definition to allow any string, this because version 2.1.0 also allows to listen  to action button callbacks: [Action buttons documentation](https://github.com/phonegap/phonegap-plugin-push/blob/v2.1.0/docs/PAYLOAD.md#action-buttons)

Finally, I modified the finish() method, so that it can receive the notification id [push.finish documentation](https://github.com/phonegap/phonegap-plugin-push/blob/v2.1.0/docs/API.md#pushfinishsuccesshandler-errorhandler-id---ios-only)