### PR TITLE
feat(NFC): add support for iOS

### DIFF
--- a/src/@ionic-native/plugins/nfc/index.ts
+++ b/src/@ionic-native/plugins/nfc/index.ts
@@ -198,6 +198,22 @@ export class NFC extends IonicNativePlugin {
   @Cordova({ sync: true })
   bytesToHexString(bytes: number[]): string { return; };
 
+  /**
+  * Starts the NFCNDEFReaderSession allowing iOS to scan NFC tags.
+  * 
+  * @returns {Promise<any>} 
+  */
+  @Cordova()
+  beginSession(): Promise<any> { return; }
+
+  /**
+   * Stops the NFCNDEFReaderSession returning control to your app.
+   * 
+   * @returns {Promise<any>} 
+   */
+  @Cordova()
+  invalidateSession(): Promise<any> { return; }
+
 }
 /**
  * @hidden

--- a/src/@ionic-native/plugins/ux-cam/index.ts
+++ b/src/@ionic-native/plugins/ux-cam/index.ts
@@ -1,15 +1,3 @@
-/**
- * This is a template for new plugin wrappers
- *
- * TODO:
- * - Add/Change information below
- * - Document usage (importing, executing main functionality)
- * - Remove any imports that you are not using
- * - Add this file to /src/index.ts (follow style of other plugins)
- * - Remove all the comments included in this template, EXCEPT the @Plugin wrapper docs and any other docs you added
- * - Remove this note
- *
- */
 import { Injectable } from '@angular/core';
 import { Plugin, Cordova, IonicNativePlugin } from '@ionic-native/core';
 
@@ -29,7 +17,7 @@ import { Plugin, Cordova, IonicNativePlugin } from '@ionic-native/core';
  * ...
  *
  *
- * this.uXCam.functionName('Hello', 123)
+ * this.uXCam.startWithKey('3jkhg3j4h5g')
  *   .then((res: any) => console.log(res))
  *   .catch((error: any) => console.error(error));
  *
@@ -51,7 +39,6 @@ export class UXCam extends IonicNativePlugin {
    * 
    * @param {string} key 
    * @returns {Promise<any>} 
-   * @memberof UXCam
    */
   @Cordova()
   startWithKey(key: string): Promise<any> {
@@ -64,7 +51,6 @@ export class UXCam extends IonicNativePlugin {
    * @param {string} key 
    * @param {string} appVariant 
    * @returns {Promise<any>} 
-   * @memberof UXCam
    */
   @Cordova()
   startWithKeyAndAppVariant(key: string, appVariant: string): Promise<any> {
@@ -75,7 +61,6 @@ export class UXCam extends IonicNativePlugin {
    * Stops the faceCamera video recording if your application uses camera
    * 
    * @returns {Promise<any>} 
-   * @memberof UXCam
    */
   @Cordova()
   stopUXCamCameraVideo(): Promise<any> {
@@ -86,7 +71,6 @@ export class UXCam extends IonicNativePlugin {
    * Stops the UXCam application and sends captured data to the server. Use this to start sending the data on UXCam server without waiting for the app going into the background.
    * 
    * @returns {Promise<any>} 
-   * @memberof UXCam
    */
   @Cordova()
   stopApplicationAndUploadData(): Promise<any> {
@@ -97,7 +81,6 @@ export class UXCam extends IonicNativePlugin {
    * You can mark a user specifically if certain condition are met making them a good user for further testing. You can then filter these users and perform further test.
    * 
    * @returns {Promise<any>} 
-   * @memberof UXCam
    */
   @Cordova()
   markUserAsFavorite(): Promise<any> {
@@ -114,7 +97,6 @@ export class UXCam extends IonicNativePlugin {
    * 
    * @param {string} screenName 
    * @returns {Promise<any>} 
-   * @memberof UXCam
    */
   @Cordova()
   tagScreenName(screenName: string): Promise<any> {
@@ -126,7 +108,6 @@ export class UXCam extends IonicNativePlugin {
    * 
    * @param {string} userName 
    * @returns {Promise<any>} 
-   * @memberof UXCam
    */
   @Cordova()
   tagUsersName(userName: string): Promise<any> {
@@ -138,7 +119,6 @@ export class UXCam extends IonicNativePlugin {
    * 
    * @param {string} eventName 
    * @returns {Promise<any>} 
-   * @memberof UXCam
    */
   @Cordova()
   addTag(eventName: string): Promise<any> {
@@ -151,7 +131,6 @@ export class UXCam extends IonicNativePlugin {
    * @param {string} eventName 
    * @param {*} properties 
    * @returns {Promise<any>} 
-   * @memberof UXCam
    */
   @Cordova()
   addTagWithProperties(eventName: string, properties: any): Promise<any> {
@@ -162,8 +141,7 @@ export class UXCam extends IonicNativePlugin {
  * Hide / un-hide the screen from being recorded. Call once with 'true' to start hiding the screen and later with 'false' to record normal contents again. Useful to hide sensitive entry fields that you would not want to record the contents of.
  * 
  * @param {boolean} occludeSensitiveScreen 
- * @returns {Promise<any>} 
- * @memberof UXCam
+ * @returns {Promise<any>}
  */
   @Cordova()
   occludeSensitiveScreen(occludeSensitiveScreen: boolean): Promise<any> {

--- a/src/@ionic-native/plugins/ux-cam/index.ts
+++ b/src/@ionic-native/plugins/ux-cam/index.ts
@@ -1,0 +1,188 @@
+/**
+ * This is a template for new plugin wrappers
+ *
+ * TODO:
+ * - Add/Change information below
+ * - Document usage (importing, executing main functionality)
+ * - Remove any imports that you are not using
+ * - Add this file to /src/index.ts (follow style of other plugins)
+ * - Remove all the comments included in this template, EXCEPT the @Plugin wrapper docs and any other docs you added
+ * - Remove this note
+ *
+ */
+import { Injectable } from '@angular/core';
+import { Plugin, Cordova, IonicNativePlugin } from '@ionic-native/core';
+
+
+/**
+ * @name UXCam
+ * @description
+ * This plugin does something
+ *
+ * @usage
+ * ```typescript
+ * import { UXCam } from '@ionic-native/ux-cam';
+ *
+ *
+ * constructor(private uXCam: UXCam) { }
+ *
+ * ...
+ *
+ *
+ * this.uXCam.functionName('Hello', 123)
+ *   .then((res: any) => console.log(res))
+ *   .catch((error: any) => console.error(error));
+ *
+ * ```
+ */
+@Plugin({
+  pluginName: 'UXCam',
+  plugin: 'cordova-uxcam', // npm package name, example: cordova-plugin-camera
+  pluginRef: 'UXCam', // the variable reference to call the plugin, example: navigator.geolocation
+  repo: 'https://github.com/uxcam/cordova-uxcam', // the github repository URL for the plugin
+  platforms: ['Android', 'iOS'], // Array of platforms supported, example: ['Android', 'iOS']
+  install: '', // OPTIONAL install command, in case the plugin requires variables
+})
+@Injectable()
+export class UXCam extends IonicNativePlugin {
+
+  /**
+   * Starts the UXCam application to ping the server, get the settings configurations and start capturing the data according to the configuration. Use startWithKey with appVariantIdentifier parameter to separate Debug and Release builds
+   * 
+   * @param {string} key 
+   * @returns {Promise<any>} 
+   * @memberof UXCam
+   */
+  @Cordova()
+  startWithKey(key: string): Promise<any> {
+    return;
+  }
+
+  /**
+   * Starts the UXCam session and sets a variant identifier for the app to differentiate builds of the same app on the dashboard.
+   * 
+   * @param {string} key 
+   * @param {string} appVariant 
+   * @returns {Promise<any>} 
+   * @memberof UXCam
+   */
+  @Cordova()
+  startWithKeyAndAppVariant(key: string, appVariant: string): Promise<any> {
+    return;
+  }
+
+  /**
+   * Stops the faceCamera video recording if your application uses camera
+   * 
+   * @returns {Promise<any>} 
+   * @memberof UXCam
+   */
+  @Cordova()
+  stopUXCamCameraVideo(): Promise<any> {
+    return;
+  }
+
+  /**
+   * Stops the UXCam application and sends captured data to the server. Use this to start sending the data on UXCam server without waiting for the app going into the background.
+   * 
+   * @returns {Promise<any>} 
+   * @memberof UXCam
+   */
+  @Cordova()
+  stopApplicationAndUploadData(): Promise<any> {
+    return;
+  }
+
+  /**
+   * You can mark a user specifically if certain condition are met making them a good user for further testing. You can then filter these users and perform further test.
+   * 
+   * @returns {Promise<any>} 
+   * @memberof UXCam
+   */
+  @Cordova()
+  markUserAsFavorite(): Promise<any> {
+    return;
+  }
+
+  @Cordova()
+  setAutomaticScreenNameTagging(enableAutomaticNameTagging: boolean): Promise<any> {
+    return;
+  }
+
+  /**
+   * UXCam captures the view controller name automatically but in case where it doesn’t (such as in OpenGL) or you would like to set a different unique name, use this function.
+   * 
+   * @param {string} screenName 
+   * @returns {Promise<any>} 
+   * @memberof UXCam
+   */
+  @Cordova()
+  tagScreenName(screenName: string): Promise<any> {
+    return;
+  }
+
+  /**
+   * UXCam uses a unique number to tag a device. You can tag a device allowing you to search for it on the dashboard and review their session further.
+   * 
+   * @param {string} userName 
+   * @returns {Promise<any>} 
+   * @memberof UXCam
+   */
+  @Cordova()
+  tagUsersName(userName: string): Promise<any> {
+    return;
+  }
+
+  /**
+   * Insert a general tag into the timeline - stores the tag with the timestamp when it was added.
+   * 
+   * @param {string} eventName 
+   * @returns {Promise<any>} 
+   * @memberof UXCam
+   */
+  @Cordova()
+  addTag(eventName: string): Promise<any> {
+    return;
+  }
+
+  /**
+   * Insert a general tag into the timeline - stores the tag with the timestamp when it was added, along with the properties to associate with this instance of the tag.
+   * 
+   * @param {string} eventName 
+   * @param {*} properties 
+   * @returns {Promise<any>} 
+   * @memberof UXCam
+   */
+  @Cordova()
+  addTagWithProperties(eventName: string, properties: any): Promise<any> {
+    return;
+  }
+
+  /**
+ * Hide / un-hide the screen from being recorded. Call once with 'true' to start hiding the screen and later with 'false' to record normal contents again. Useful to hide sensitive entry fields that you would not want to record the contents of.
+ * 
+ * @param {boolean} occludeSensitiveScreen 
+ * @returns {Promise<any>} 
+ * @memberof UXCam
+ */
+  @Cordova()
+  occludeSensitiveScreen(occludeSensitiveScreen: boolean): Promise<any> {
+    return;
+  }
+
+  @Cordova()
+  addVerificationListener(): Promise<any> {
+    return;
+  }
+
+  @Cordova()
+  urlForCurrentUser(): Promise<any> {
+    return;
+  }
+
+  @Cordova()
+  urlForCurrentSession(): Promise<any> {
+    return;
+  }
+
+}


### PR DESCRIPTION
The last version of NFC plugin now supports NFC reading on iOS. I added the two required methods: beginSession and invalidateSession that need to be executed before and after reading.