### PR TITLE
chore(package): bump Angular

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,9 +6,9 @@
   "author": "Ionic Team <hi@ionic.io> (https://ionic.io)",
   "license": "MIT",
   "devDependencies": {
-    "@angular/compiler": "4.4.4",
-    "@angular/compiler-cli": "4.4.4",
-    "@angular/core": "4.4.4",
+    "@angular/compiler": "5.0.0",
+    "@angular/compiler-cli": "5.0.0",
+    "@angular/core": "5.0.0",
     "@types/cordova": "0.0.34",
     "@types/jasmine": "^2.5.51",
     "@types/node": "^7.0.27",
@@ -39,12 +39,12 @@
     "q": "1.5.0",
     "queue": "4.2.1",
     "rimraf": "2.6.1",
-    "rxjs": "5.4.3",
+    "rxjs": "5.5.2",
     "semver": "5.3.0",
     "tslint": "3.15.1",
     "tslint-ionic-rules": "0.0.8",
-    "typescript": "2.3.4",
-    "zone.js": "0.8.18"
+    "typescript": "~2.4.2",
+    "zone.js": "^0.8.18"
   },
   "scripts": {
     "start": "npm run test:watch",


### PR DESCRIPTION
The Ionic-Angular repo now uses Angular 5 so we could also update ionic-native.