### PR TITLE
Update the doc for firebase

### DIFF
--- a/src/@ionic-native/plugins/firebase/index.ts
+++ b/src/@ionic-native/plugins/firebase/index.ts
@@ -216,7 +216,7 @@ export class Firebase extends IonicNativePlugin {
   @Cordova({
     platforms: ['Android']
   })
-  setConfigSettings(settings: any): Promise<any> { return; }
+  setCosnfigSetting(settings: any): Promise<any> { return; }
 
   /**
    * Set defaults in the Remote Config


### PR DESCRIPTION
The setConfigSetting is available only for android. It is used at several places for enabling developer mode. For iOS, this can be done using the following code snippet in the '(void)fetch:(CDVInvokedUrlCommand *)command' method:

FIRRemoteConfig* remoteConfig = [FIRRemoteConfig remoteConfig];
FIRRemoteConfigSettings *remoteConfigSettings = [[FIRRemoteConfigSettings alloc]initWithDeveloperModeEnabled:YES];
remoteConfig.configSettings = remoteConfigSettings;