### PR TITLE
In SocialSharing plugin, the provider is added

### DIFF
--- a/src/@ionic-native/plugins/social-sharing/index.ts
+++ b/src/@ionic-native/plugins/social-sharing/index.ts
@@ -11,6 +11,15 @@ import { Cordova, Plugin, IonicNativePlugin } from '@ionic-native/core';
  *
  * @usage
  * ```typescript
+ * // In your app.module.ts
+ * import { SocialSharing } from '@ionic-native/social-sharing';
+ *
+ * providers: [
+ *   SocialSharing,
+ * ]
+ * ````
+ *
+ * ```typescript
  * import { SocialSharing } from '@ionic-native/social-sharing';
  *
  * constructor(private socialSharing: SocialSharing) { }


### PR DESCRIPTION
The provider should be added in module declaration or we get `No provider for SocialSharing!` error.