### PR TITLE
fix(jins-meme): update plugin repo to one which contains a package.json

### DIFF
--- a/src/@ionic-native/plugins/jins-meme/index.ts
+++ b/src/@ionic-native/plugins/jins-meme/index.ts
@@ -31,10 +31,10 @@ declare const cordova: any;
  * ```
  */
 @Plugin({
-  pluginName: 'Jins Meme',
-  plugin: 'JinsMemeSDK-Plugin-Cordova',
-  pluginRef: 'cordova.plugins.JinsMemePlugin',
-  repo: 'https://github.com/jins-meme/JinsMemeSDK-Plugin-Cordova',
+  pluginName: 'JINS MEME ES',
+  plugin: 'cordova-plugin-jins-meme-es',
+  pluginRef: 'com.jins_jp.meme.plugin',
+  repo: 'https://github.com/BlyncSync/cordova-plugin-jins-meme-es',
   platforms: ['Android', 'iOS']
 })
 @Injectable()


### PR DESCRIPTION
The most important change here is to point to the BlyncSync version of the plugin, which is actively maintained.  The jins-meme version lacks a package.json, which causes issues on some platforms that will result in an inability to build.

The plugin name should be JINS MEME ES (ES for Eye-Sensing,) as this is how the product is actually named: not "Jins Meme."

The BlyncSync plugin also uses standard naming convention for cordova plugins (cordova-plugin-jins-meme-es)