### PR TITLE
/plugins/alipay/index.ts add 'string' as an alternative type for 'pay()' input parameter;

### DIFF
--- a/src/@ionic-native/plugins/alipay/index.ts
+++ b/src/@ionic-native/plugins/alipay/index.ts
@@ -101,17 +101,17 @@ export interface AlipayOrder {
   plugin: 'cordova-alipay-base',
   pluginRef: 'Alipay.Base',
   repo: 'https://github.com/xueron/cordova-alipay-base',
-  install: 'ionic cordova plugin add cordova-alipay-base --variable APP_ID=your_app_id',
-  installVariables: ['APP_ID'],
+  install: 'ionic cordova plugin add cordova-alipay-base --variable ALI_PID=your_app_id',
+  installVariables: ['ALI_PID'],
   platforms: ['Android', 'iOS']
 })
 @Injectable()
 export class Alipay extends IonicNativePlugin {
   /**
    * Open Alipay to perform App pay
-   * @param order { AlipayOrder } alipay options
+   * @param order { AlipayOrder | string } alipay options
    * @returns {Promise<any>} Returns a Promise that resolves with the success return, or rejects with an error.
    */
   @Cordova()
-  pay(order: AlipayOrder): Promise<any> { return; }
+  pay(order: AlipayOrder | string): Promise<any> { return; }
 }


### PR DESCRIPTION

the latest version (2017-11-21) of the server-side now undertakes the job of assembling the json object into a parameters-string that can be inserted directly into the pay() function; and returns this parameter-string instead of the corresponding json (which is the previous behavior)

I checked the corresponding Alipay Cordova plugin([https://github.com/xueron/cordova-alipay-base](https://github.com/xueron/cordova-alipay-base)), and found out that the 'execute()' does also expect a string input (see below code snipe) :
```
@Override
    public boolean execute(String action, JSONArray args, final CallbackContext callbackContext) throws JSONException {
        Log.d(TAG, "Execute:" + action + " with :" + args.toString());
        if (action.equals("pay")) {
            String payParameters = null;
            if (args.get(0) instanceof JSONObject){
                JSONObject obj = args.getJSONObject(0);
                payParameters = buildCallString(obj, callbackContext);
            }else if (args.get(0) instanceof String){
                payParameters = (String) args.get(0);
            }else{
                callbackContext.error("Unsported parameter:" + args.get(0));
                return true;
            }
            doCallPayment(callbackContext, payParameters);
        }else{
            callbackContext.error("Known service: " + action);
        }
        return true;
    }
```

change 'installVariables' name to 'ALI_PID' for Alipay cordova plugin. I found out this problems by installing the plugin myself