### PR TITLE
fix(network-interface) remove trailing whitespace to fix linter report

### DIFF
--- a/src/@ionic-native/plugins/network-interface/index.ts
+++ b/src/@ionic-native/plugins/network-interface/index.ts
@@ -37,7 +37,7 @@ export class NetworkInterface extends IonicNativePlugin {
 
   @Cordova()
   getIPAddress(): Promise<string> { return; }
-  
+
   /**
    * Gets the WiFi IP address
    * @param success {Function} Callback used when successful


### PR DESCRIPTION
This file had some trailing whitespace which appears to be causing CI to fail for unrelated pull requests.