### PR TITLE
docs(android-permissions): note checkPermission return/result format and Android API version 26 changes that impact requestPermission and requestPermissions

### DIFF
--- a/src/@ionic-native/plugins/android-permissions/index.ts
+++ b/src/@ionic-native/plugins/android-permissions/index.ts
@@ -18,7 +18,7 @@ import { Injectable } from '@angular/core';
  * ...
  *
  * this.androidPermissions.checkPermission(this.androidPermissions.PERMISSION.CAMERA).then(
- *   success => console.log('Permission granted'),
+ *   result => console.log('Has permission?',result.hasPermission),
  *   err => this.androidPermissions.requestPermission(this.androidPermissions.PERMISSION.CAMERA)
  * );
  *

--- a/src/@ionic-native/plugins/android-permissions/index.ts
+++ b/src/@ionic-native/plugins/android-permissions/index.ts
@@ -25,6 +25,8 @@ import { Injectable } from '@angular/core';
  * this.androidPermissions.requestPermissions([this.androidPermissions.PERMISSION.CAMERA, this.androidPermissions.PERMISSION.GET_ACCOUNTS]);
  *
  * ```
+ *
+ * Android 26 and above: due to Android 26's changes to permissions handling (permissions are requested at time of use rather than at runtime,) if your app does not include any functions (eg. other Ionic Native plugins) that utilize a particular permission, then `requestPermission()` and `requestPermissions()` will resolve immediately with no prompt shown to the user.  Thus, you must include a function utilizing the feature you would like to use before requesting permission for it.
  */
 @Plugin({
   pluginName: 'AndroidPermissions',


### PR DESCRIPTION
Closes #2000

`checkPermission()` resolves with an object whose property `hasPermission<boolean>` indicates permission state; current documentation shows that the resolution = permitted, rejection = not permitted.

`requestPermission()` (and `requestPermissions()` do not do anything as of Android API version 26 if the app does that include any functions (eg. other Ionic Native plugins) that consume said permissions -- that is, you cannot request Bluetooth permissions if you don't use Bluetooth in any way.  If you try, nothing happens (the promise resolves instantly without a prompt being shown to the user.)