### PR TITLE
chore()/linting(): remove trailing whitespace in network-permissions

### DIFF
--- a/src/@ionic-native/plugins/network-interface/index.ts
+++ b/src/@ionic-native/plugins/network-interface/index.ts
@@ -37,7 +37,7 @@ export class NetworkInterface extends IonicNativePlugin {
 
   @Cordova()
   getIPAddress(): Promise<string> { return; }
-  
+
   /**
    * Gets the WiFi IP address
    * @param success {Function} Callback used when successful


### PR DESCRIPTION
The nittiest of nit-picks, but I noticed that this line caused my other PR to fail due to a linting error.

My apologies if this annoys anyone, but it should cause some more unrelated CI tests to pass.

See #2182 and #2183 for examples of this error's impact on CI tests