### PR TITLE
DO NOT MERGE: fix(music-controls): explicitly optional platform-specific variables

### DIFF
--- a/src/@ionic-native/plugins/music-controls/index.ts
+++ b/src/@ionic-native/plugins/music-controls/index.ts
@@ -10,15 +10,15 @@ export interface MusicControlsOptions {
   dismissable: boolean;
   hasPrev: boolean;
   hasNext: boolean;
-  hasSkipForward: boolean;
-  hasSkipBackward: boolean;
-  skipForwardInterval: number;
-  skipBackwardInterval: number;
+  hasSkipForward?: boolean; // iOS only
+  hasSkipBackward?: boolean; // iOS only
+  skipForwardInterval?: number; // iOS only
+  skipBackwardInterval?: number; // iOS only // iOS only
   hasClose: boolean;
-  album: string;
-  duration: number;
-  elapsed: number;
-  ticker: string;
+  album?: string; // iOS only
+  duration?: number; // iOS only
+  elapsed?: number; // iOS only
+  ticker?: string; // Android only
 }
 
 /**


### PR DESCRIPTION
In accordance with #1939, this commit changes the MusicControlsOptions type to match the documented example.

Marked DO NOT MERGE as I am requesting that @Remco75 test these changes.  This tag should be removed after testing.