### PR TITLE
Type changed to "any" from "PushOptions"

### DIFF
--- a/src/@ionic-native/plugins/push/index.ts
+++ b/src/@ionic-native/plugins/push/index.ts
@@ -269,7 +269,7 @@ export type PushEvent = string;
  *
  * // to initialize push notifications
  *
- * const options: PushOptions = {
+ * const options: any = {
  *    android: {},
  *    ios: {
  *        alert: 'true',


### PR DESCRIPTION
Keeping "const options: PushOptions"  as per documentation
with value " android: {},
 ios: {
     alert: 'true',
     badge: true,
     sound: 'false'
 },
 windows: {},
 browser: {
     pushServiceURL: 'http://push.api.phonegap.com/v1/push'
 }
};"

will throw:
Type '{ android: {}; ios: { alert: "true"; badge: true; sound: "false"; }; windows: {}; browser: { push...' is not assignable to type 'PushOptions'.
  Types of property 'android' are incompatible.
    Type '{}' is not assignable to type 'AndroidPushOptions'.
      Property 'senderID' is missing in type '{}'."

Solution is to keep the type "any" instead of "PushOptions".