### PR TITLE
ref(local-notifications): Replace registerPermission by requestPermission

### DIFF
--- a/src/@ionic-native/plugins/local-notifications/index.ts
+++ b/src/@ionic-native/plugins/local-notifications/index.ts
@@ -300,11 +300,11 @@ export class LocalNotifications extends IonicNativePlugin {
   getAllTriggered(): Promise<Array<ILocalNotification>> { return; }
 
   /**
-   * Register permission to show notifications if not already granted.
+   * Request permission to show notifications if not already granted.
    * @returns {Promise<boolean>}
    */
   @Cordova()
-  registerPermission(): Promise<boolean> { return; }
+  requestPermission(): Promise<boolean> { return; }
 
   /**
    * Informs if the app has the permission to show notifications.


### PR DESCRIPTION
Following cordova-plugin-local-notifications updates (https://github.com/katzer/cordova-plugin-local-notifications).

Method to gain permission change its name but signature stay the same

(first contribution ever here so don't hesitate to mentor me and to be nice ;) 