### PR TITLE
feat(http): added x509 client authentication

### DIFF
--- a/src/@ionic-native/plugins/http/index.ts
+++ b/src/@ionic-native/plugins/http/index.ts
@@ -76,6 +76,20 @@ export class HTTP extends IonicNativePlugin {
   @Cordova({ sync: true })
   getBasicAuthHeader(username: string, password: string): { Authorization: string; } { return; }
 
+
+  /**
+   * This sets up X509 Authentication for all future Https requests
+   * @param pkcs10Container 
+   * @param password 
+   */
+  @Cordova()
+  setX509AuthClientCredentials(pkcs10Container: ArrayBuffer, password?: ArrayBuffer): void{ return; }
+
+  /**
+   * This resets the given Credentials for X509 client Authentication
+   */
+  @Cordova()
+  resetX509AuthClientCredentials(): void{ return; }
   /**
    * This sets up all future requests to use Basic HTTP authentication with the given username and password.
    * @param username {string} Username

--- a/src/@ionic-native/plugins/http/index.ts
+++ b/src/@ionic-native/plugins/http/index.ts
@@ -83,13 +83,13 @@ export class HTTP extends IonicNativePlugin {
    * @param password 
    */
   @Cordova()
-  setX509AuthClientCredentials(pkcs10Container: ArrayBuffer, password?: ArrayBuffer): void{ return; }
+  setX509AuthClientCredentials(pkcs10Container: ArrayBuffer, password?: ArrayBuffer): void { return; }
 
   /**
    * This resets the given Credentials for X509 client Authentication
    */
   @Cordova()
-  resetX509AuthClientCredentials(): void{ return; }
+  resetX509AuthClientCredentials(): void { return; }
   /**
    * This sets up all future requests to use Basic HTTP authentication with the given username and password.
    * @param username {string} Username


### PR DESCRIPTION
This PR depends on https://github.com/silkimen/cordova-plugin-advanced-http/pull/56 and extends the http plugin to enable x509 authentication for https requests.

depends on: https://github.com/silkimen/cordova-plugin-advanced-http/pull/56