### PR TITLE
docs(code-push) updated example link to an up to date one

### DIFF
--- a/src/@ionic-native/plugins/code-push/index.ts
+++ b/src/@ionic-native/plugins/code-push/index.ts
@@ -400,7 +400,7 @@ export interface DownloadProgress {
  * @description
  * CodePush plugin for Cordova by Microsoft that supports iOS and Android.
  *
- * For more info, please see https://github.com/ksachdeva/ionic2-code-push-example
+ * For more info, please see https://github.com/Dellos7/example-cordova-code-push-plugin
  *
  * @usage
  * ```typescript


### PR DESCRIPTION
The example: https://github.com/Dellos7/example-cordova-code-push-plugin contains an up-to-date example of how to use this plugin with Ionic; the current link is an outdated one.