### PR TITLE
Add: accept params argument for Map.toDataURL [google-maps]

### DIFF
--- a/src/@ionic-native/plugins/google-maps/index.ts
+++ b/src/@ionic-native/plugins/google-maps/index.ts
@@ -679,6 +679,12 @@ export interface TileOverlayOptions {
   [key: string]: any;
 }
 
+export interface ToDataUrlOptions {
+  /**
+   * True if you want get high quality map snapshot
+   */
+  uncompress?: boolean;
+}
 
 /**
  * @hidden
@@ -2365,7 +2371,7 @@ export class GoogleMap extends BaseClass {
    * @return {Promise<any>}
    */
   @CordovaInstance()
-  toDataURL(): Promise<any> { return; }
+  toDataURL(params?: ToDataUrlOptions): Promise<any> { return; }
 
   // /**
   //  * @return {Promise<KmlOverlay | any>}


### PR DESCRIPTION
Cordova google maps plugin `Map.toDataUrl` method accepts optional `params`, but was missing from ionic-native plugin. This PR adds interface and the optional argument.

See original plugin code here:
https://github.com/mapsplugin/cordova-plugin-googlemaps/blob/4eb2ac928ca923a521d5a6c41e27aa3b1f4cec6d/www/Map.js#L584 