### PR TITLE
fix(web-intent): rename `onNewIntent` to `onIntent`

### DIFF
--- a/src/@ionic-native/plugins/web-intent/index.ts
+++ b/src/@ionic-native/plugins/web-intent/index.ts
@@ -147,12 +147,13 @@ export class WebIntent extends IonicNativePlugin {
   getUri(): Promise<string> { return; };
 
   /**
+   * Returns the content of the intent used whenever the application activity is launched
    * @returns {Observable<string>}
    */
   @Cordova({
     observable: true
   })
-  onNewIntent(): Observable<string> { return; };
+  onIntent(): Observable<string> { return; };
 
   /**
    * Sends a custom intent passing optional extras
@@ -174,12 +175,6 @@ export class WebIntent extends IonicNativePlugin {
    */
   @Cordova({ sync: true })
   unregisterBroadcastReceiver(): void { }
-
-  /**
-  * Returns the content of the intent used whenever the application activity is launched
-  */
-  @Cordova({ sync: true })
-  onIntent(): void { }
 
   /**
   *


### PR DESCRIPTION
The `onNewIntent` function doesn't exist in `darryncampbell-cordova-plugin-intent`, it's actually called `onIntent`.

Source: https://github.com/darryncampbell/darryncampbell-cordova-plugin-intent/blob/master/www/IntentShim.js#L62

This PR renames `onNewIntent` to `onIntent`, as the implementation was right (should return an Observable). It also removes the previous `onIntent` as it was wrong and shouldn't return `void` anyway.

The change has been tested on device with latest `ionic-angular@3.9.2` and over `@ionic-native/web-intent@4.5.2`.