### PR TITLE
Add missing name. prefix for ContactFieldTypes

### DIFF
--- a/src/@ionic-native/plugins/contacts/index.ts
+++ b/src/@ionic-native/plugins/contacts/index.ts
@@ -3,7 +3,7 @@ import { CordovaInstance, InstanceProperty, Plugin, getPromise, InstanceCheck, c
 declare const window: any,
   navigator: any;
 
-export type ContactFieldType = '*' | 'addresses' | 'birthday' | 'categories' | 'country' | 'department' | 'displayName' | 'emails' | 'familyName' | 'formatted' | 'givenName' | 'honorificPrefix' | 'honorificSuffix' | 'id' | 'ims' | 'locality' | 'middleName' | 'name' | 'nickname' | 'note' | 'organizations' | 'phoneNumbers' | 'photos' | 'postalCode' | 'region' | 'streetAddress' | 'title' | 'urls';
+export type ContactFieldType = '*' | 'addresses' | 'birthday' | 'categories' | 'country' | 'department' | 'displayName' | 'emails' | 'name.familyName' | 'name.formatted' | 'name.givenName' | 'name.honorificPrefix' | 'name.honorificSuffix' | 'id' | 'ims' | 'locality' | 'name.middleName' | 'name' | 'nickname' | 'note' | 'organizations' | 'phoneNumbers' | 'photos' | 'postalCode' | 'region' | 'streetAddress' | 'title' | 'urls';
 
 export interface IContactProperties {
 


### PR DESCRIPTION
Problem: 
Filtering by ContactFieldTypes such as 'familyName'/'formatted'/'givenName' gives bad results. 

Proposal: 
Add 'name.' prefix to ContactFieldTypes that are properties of ContactName

Additional info: 
I know this plugin is deprecated, but I think a lot of people would still benefit from this.