### PR TITLE
docs(navigation-bar): rename mismatched function

### DIFF
--- a/src/@ionic-native/plugins/navigation-bar/index.ts
+++ b/src/@ionic-native/plugins/navigation-bar/index.ts
@@ -17,7 +17,7 @@ import { Cordova, Plugin, IonicNativePlugin } from '@ionic-native/core';
  * ...
  *
  * let autoHide: boolean = true;
- * this.navigationBar.hide(autoHide);
+ * this.navigationBar.setUp(autoHide);
  * ```
  */
 @Plugin({


### PR DESCRIPTION
In line 20, "this.navigationBar.hide(autoHide);". But there is no such a function .hide(). It shoud be correct as "this.navigationBar.setUp(autoHide);".