### PR TITLE
feat(firebase-dynamic-links): update to conform to the latest version of the plugin

### DIFF
--- a/src/@ionic-native/plugins/firebase-dynamic-links/index.ts
+++ b/src/@ionic-native/plugins/firebase-dynamic-links/index.ts
@@ -1,22 +1,19 @@
 import { Injectable } from '@angular/core';
 import { Plugin, Cordova, IonicNativePlugin } from '@ionic-native/core';
+import { Observable } from 'rxjs/Observable';
 
-export interface DynamicLinksOptions {
-  title: string;
-  message: string;
-  deepLink?: string;
-  callToActionText?: string;
+export interface IDynamicLink {
+  matchType: 'Weak' | 'Strong';
+  deepLink: string;
 }
 
 /**
  * @beta
  * @name Firebase Dynamic Links
  * @description
- * Cordova plugin for Firebase Invites and Firebase Dynamic Links
+ * Cordova plugin for Firebase Dynamic Links
  *
  * Variables APP_DOMAIN and APP_PATH specify web URL where your app will start an activity to handle the link. They also used to setup support for App Indexing.
- * Variable REVERSED_CLIENT_ID can be found in your GoogleService-Info.plist under the same key name.
- * Variable PHOTO_LIBRARY_USAGE_DESCRIPTION specifies required value for NSPhotoLibraryUsageDescription on iOS.
  * Go to firebase console and export google-services.json and GoogleService-Info.plist. Put those files into the root of your cordova app folder.
  *
  * Preferences:
@@ -41,17 +38,6 @@ export interface DynamicLinksOptions {
  * constructor(private firebaseDynamicLinks: FirebaseDynamicLinks) { }
  *
  * ...
- * // The deepLink and callToActionText properties are optional
- * const options: DynamicLinksOptions = {
- *   title: 'My Title';
- *   message: 'My message';
- *   deepLink: 'http://example.com/';
- *   callToActionText: 'Message on button';
- * }
- *
- * this.firebaseDynamicLinks.sendInvitation(options)
- *   .then((res: any) => console.log(res))
- *   .catch((error: any) => console.error(error));
  *
  * this.firebaseDynamicLinks.onDynamicLink()
  *   .then((res: any) => console.log(res)) //Handle the logic here after opening the app with the Dynamic link
@@ -75,17 +61,12 @@ export class FirebaseDynamicLinks extends IonicNativePlugin {
 
   /**
    * Registers callback that is triggered on each dynamic link click.
-   * @return {Promise<any>} Returns a promise
+   * @return {Observable<IDynamicLink>} Returns an observable
    */
-  @Cordova()
-  onDynamicLink(): Promise<any> { return; }
-
-  /**
-   * Display invitation dialog.
-   * @param options {DynamicLinksOptions} Some param to configure something
-   * @return {Promise<any>} Returns a promise
-   */
-  @Cordova()
-  sendInvitation(options: DynamicLinksOptions): Promise<any> { return; }
+  @Cordova({
+    callbackOrder: 'reverse',
+    observable: true,
+  })
+  onDynamicLink(): Observable<IDynamicLink> { return; }
 
 }


### PR DESCRIPTION
*Summary*

The `sendInvitation` method was removed as well as the related configuration variables. Also `onDynamicLink ` can be called multiple times during the app lifecycle so it makes more sense that it is an Observable.

