### PR TITLE
Fixed AndroidExoPlayer capitalization

### DIFF
--- a/src/@ionic-native/plugins/android-exoplayer/index.ts
+++ b/src/@ionic-native/plugins/android-exoplayer/index.ts
@@ -181,7 +181,7 @@ export interface AndroidExoPlayerControllerConfig {
   platforms: ['Android']
 })
 @Injectable()
-export class AndroidExoplayer extends IonicNativePlugin {
+export class AndroidExoPlayer extends IonicNativePlugin {
   /**
    * Show the player.
    * @param parameters {AndroidExoPlayerParams} Parameters


### PR DESCRIPTION
In the [documentation](https://ionicframework.com/docs/native/android-exoplayer/) it states to use:

```
import { AndroidExoPlayer } from '@ionic-native/android-exoplayer';
```

This PR fixes a capitalization error to change the class name from `AndroidExoplayer` to `AndroidExoPlayer` to match the docs.