### PR TITLE
feat(image-picker): add DATA_URL as an option to ImagePicker

### DIFF
--- a/src/@ionic-native/plugins/image-picker/index.ts
+++ b/src/@ionic-native/plugins/image-picker/index.ts
@@ -23,9 +23,17 @@ export interface ImagePickerOptions {
   quality?: number;
 
   /**
-   * Output type, defaults to 0  (FILE_URI).
+   * Choose the format of the return value.
+   * Defined in ImagePicker.OutputType. Default is FILE_URI.
+   *      FILE_URI : 0,   Return image file URI,
+   *      DATA_URL : 1,   Return image as base64-encoded string
    */
   outputType?: number;
+}
+
+export enum OutputType {
+  FILE_URL = 0,
+  DATA_URL
 }
 
 /**


### PR DESCRIPTION
As documented in the image picker plugin, it also supports a data url, just like the camera does. However, this option is not documented in Ionic Native currently. I've added this documentation, and have also added an enum with a naming pattern that matches the DestinationType in Camera.

Docs from the image picker plugin:
```
    ...
    // output type, defaults to FILE_URIs.
    // available options are 
    // window.imagePicker.OutputType.FILE_URI (0) or 
    // window.imagePicker.OutputType.BASE64_STRING (1)
    outputType: int
};
```