### PR TITLE
docs(intercom): add deprecated notice for setSecureMode

### DIFF
--- a/src/@ionic-native/plugins/intercom/index.ts
+++ b/src/@ionic-native/plugins/intercom/index.ts
@@ -60,6 +60,7 @@ export class Intercom extends IonicNativePlugin {
    * @param secureHash {string}
    * @param secureData {any}
    * @return {Promise<any>} Returns a promise
+   * @deprecated Use setUserHash instead as of Intercom Cordova 4.0.0 and higher https://github.com/intercom/intercom-cordova/blob/master/CHANGELOG.md#400-2017-08-29
    */
   @Cordova()
   setSecureMode(secureHash: string, secureData: any): Promise<any> { return; }


### PR DESCRIPTION
As of Intercom Cordova 4.0.0 setSecureMode has been removed. Updating docs to indicate to use setUserHash instead https://github.com/intercom/intercom-cordova/blob/master/CHANGELOG.md#400-2017-08-29

Unsure if this is the correct syntax as wasn't sure how to run the docs locally. Any guidance on setting that up and correct syntax for would be appreciated 👍 