### PR TITLE
added the showOpenWithDialog() from cordova plugin

### DIFF
--- a/src/@ionic-native/plugins/file-opener/index.ts
+++ b/src/@ionic-native/plugins/file-opener/index.ts
@@ -44,6 +44,19 @@ export class FileOpener extends IonicNativePlugin {
   open(filePath: string, fileMIMEType: string): Promise<any> { return; }
 
   /**
+   * Open a choose file dialog
+   * @param filePath {string} File Path
+   * @param fileMIMEType {string} File MIME Type
+   * @returns {Promise<any>}
+   */
+  @Cordova({
+    callbackStyle: 'object',
+    successName: 'success',
+    errorName: 'error'
+  })
+  showOpenWithDialog(filePath: string, fileMIMEType: string): Promise<any> { return; }
+  
+  /**
    * Uninstalls a package
    * @param packageId {string}  Package ID
    * @returns {Promise<any>}


### PR DESCRIPTION
the pwlin/cordova-plugin-file-opener2 plugin adds a showOpenWithDialog() function which behaves similar to the open function, however this prompts the user to open said file in an external app vs opening in your app. This commit enables the showOpenWithDialog() function to the @ionic-native version.

In android this function auto opens any app available to use the said MIME type.
In iOS this function prompts the user to pick an app to open with using the ExternalFileUtil interface