### PR TITLE
docs(in-app-browser): insertCSS example update

### DIFF
--- a/src/@ionic-native/plugins/in-app-browser/index.ts
+++ b/src/@ionic-native/plugins/in-app-browser/index.ts
@@ -155,7 +155,7 @@ export class InAppBrowserObject {
  * @description Launches in app Browser
  * @usage
  * ```typescript
- * import { InAppBrowser } from '@ionic-native/in-app-browser';
+ * import { InAppBrowser, InAppBrowserEvent } from '@ionic-native/in-app-browser';
  *
  * constructor(private iab: InAppBrowser) { }
  *
@@ -166,7 +166,12 @@ export class InAppBrowserObject {
  * const browser = this.iab.create('https://ionicframework.com/');
  *
  * browser.executeScript(...);
+ *
  * browser.insertCSS(...);
+ * browser.on('loadstop').subscribe((event: InAppBrowserEvent) => {
+ *    browser.insertCSS({ code: "body{color: red;" });
+ * });
+ *
  * browser.close();
  *
  * ```

--- a/src/@ionic-native/plugins/in-app-browser/index.ts
+++ b/src/@ionic-native/plugins/in-app-browser/index.ts
@@ -155,7 +155,7 @@ export class InAppBrowserObject {
  * @description Launches in app Browser
  * @usage
  * ```typescript
- * import { InAppBrowser, InAppBrowserEvent } from '@ionic-native/in-app-browser';
+ * import { InAppBrowser } from '@ionic-native/in-app-browser';
  *
  * constructor(private iab: InAppBrowser) { }
  *
@@ -168,7 +168,7 @@ export class InAppBrowserObject {
  * browser.executeScript(...);
  *
  * browser.insertCSS(...);
- * browser.on('loadstop').subscribe((event: InAppBrowserEvent) => {
+ * browser.on('loadstop').subscribe(event => {
  *    browser.insertCSS({ code: "body{color: red;" });
  * });
  *


### PR DESCRIPTION
The current example in the docs is incomplete and thus quite useless. Just on its own won't manipulate the CSS of a loaded page. It requires the InAppBrowserEvent, and using it in the callback.