### PR TITLE
feat(jins-meme): enable background mode data collection

### DIFF
--- a/src/@ionic-native/plugins/jins-meme/index.ts
+++ b/src/@ionic-native/plugins/jins-meme/index.ts
@@ -31,10 +31,10 @@ declare const cordova: any;
  * ```
  */
 @Plugin({
-  pluginName: 'JINS MEME ES',
-  plugin: 'cordova-plugin-jins-meme-es',
-  pluginRef: 'com.jins_jp.meme.plugin',
-  repo: 'https://github.com/BlyncSync/cordova-plugin-jins-meme-es',
+  pluginName: 'JINS MEME',
+  plugin: 'cordova-plugin-jins-meme',
+  pluginRef: 'JinsMemePlugin',
+  repo: 'https://github.com/BlyncSync/cordova-plugin-jins-meme',
   platforms: ['Android', 'iOS']
 })
 @Injectable()
@@ -77,7 +77,7 @@ export class JinsMeme extends IonicNativePlugin {
   connect(target: string): Observable<any> {
     return new Observable<any>((observer: any) => {
       let data = cordova.plugins.JinsMemePlugin.connect(target, observer.next.bind(observer), observer.complete.bind(observer), observer.error.bind(observer));
-      return () => console.log(data);
+      return data;
     });
   }
   /**


### PR DESCRIPTION
In order to enable background mode data collection we used the cordova-plugin-background-mode plugin in a new Cordova plugin repo, cordova-plugin-jins-meme (vs. cordova-plugin-jins-meme-es.)  We opted to maintain the old repository for backwards-compatibility as we have multiple apps using various versions; this is simplest.

Another unrelated change was made to silence unnecessary console logging.