### PR TITLE
feat(zeroconf) add watchAddressFamily and registerAddressFamily

### DIFF
--- a/src/@ionic-native/plugins/zeroconf/index.ts
+++ b/src/@ionic-native/plugins/zeroconf/index.ts
@@ -131,4 +131,12 @@ export class Zeroconf extends IonicNativePlugin {
    */
   @Cordova()
   reInit(): Promise<void> { return; }
+  /**
+   * Family of addresses to register: ipv4, ipv6 or any.
+   */
+  registerAddressFamily: 'ipv4' | 'ipv6' | 'any';
+  /**
+   * Family of addresses to watch for: ipv4, ipv6 or any.
+   */
+  watchAddressFamily: 'ipv4' | 'ipv6' | 'any';
 }


### PR DESCRIPTION
As mentioned in [zeroconf cordova plugin doc](https://github.com/becvert/cordova-plugin-zeroconf#usage), setting the watchAddressFamily and registerAddressFamily speed things up.