### PR TITLE
feat(call-log): add operator 'like' and array of values

### DIFF
--- a/src/@ionic-native/plugins/call-log/index.ts
+++ b/src/@ionic-native/plugins/call-log/index.ts
@@ -3,8 +3,8 @@ import { Cordova, IonicNativePlugin, Plugin } from '@ionic-native/core';
 
 export interface CallLogObject {
   name: string;
-  value: string;
-  operator: '==' | '!=' | '>' | '>=' | '<' | '<=';
+  value: string|Array<string>;
+  operator: '==' | '!=' | '>' | '>=' | '<' | '<=' | 'like';
 }
 
 /**


### PR DESCRIPTION
Hello, thanks for the previous merge.

We updated our plugin to 1.2.0, added the 'like' filter, and value can now be also an array.