### PR TITLE
fix(card-io): Fix typo in the "suppressManual" property name.

### DIFF
--- a/src/@ionic-native/plugins/card-io/index.ts
+++ b/src/@ionic-native/plugins/card-io/index.ts
@@ -21,7 +21,7 @@ export interface CardIOOptions {
   /**
    * 	Removes the keyboard button from the scan screen.
    */
-  supressManual?: boolean;
+  suppressManual?: boolean;
 
   /**
    * The postal code will only collect numeric input. Set this if you know the expected country's postal code has only numeric postal codes.


### PR DESCRIPTION
Came across it while implementing the functionality. The manual entry button wouldn't go away. After some digging noticed that the Ionic docs had a typo in the property name.