### PR TITLE
docs(uptime): add iOS support

### DIFF
--- a/src/@ionic-native/plugins/uptime/index.ts
+++ b/src/@ionic-native/plugins/uptime/index.ts
@@ -1,5 +1,5 @@
-import {Injectable} from '@angular/core';
-import {Cordova, IonicNativePlugin, Plugin} from '@ionic-native/core';
+import { Injectable } from '@angular/core';
+import { Cordova, IonicNativePlugin, Plugin } from '@ionic-native/core';
 
 /**
  * @name Uptime
@@ -15,8 +15,8 @@ import {Cordova, IonicNativePlugin, Plugin} from '@ionic-native/core';
  * ...
  *
  * this.uptime.getUptime()
- *   .then((uptime: string) => console.log(uptime))
- *   .catch((error: any) => console.log(error));
+ *   .then(uptime => console.log(uptime))
+ *   .catch(error => console.log(error));
  *
  * ```
  */

--- a/src/@ionic-native/plugins/uptime/index.ts
+++ b/src/@ionic-native/plugins/uptime/index.ts
@@ -25,8 +25,6 @@ import { Cordova, IonicNativePlugin, Plugin } from '@ionic-native/core';
   plugin: 'cordova-plugin-uptime',
   pluginRef: 'Uptime',
   repo: 'https://github.com/s1lviu/cordova-plugin-uptime',
-  install: '',
-  installVariables: [],
   platforms: ['Android', 'iOS']
 })
 @Injectable()

--- a/src/@ionic-native/plugins/uptime/index.ts
+++ b/src/@ionic-native/plugins/uptime/index.ts
@@ -1,5 +1,5 @@
-import { Injectable } from '@angular/core';
-import { Cordova, IonicNativePlugin, Plugin } from '@ionic-native/core';
+import {Injectable} from '@angular/core';
+import {Cordova, IonicNativePlugin, Plugin} from '@ionic-native/core';
 
 /**
  * @name Uptime
@@ -15,7 +15,7 @@ import { Cordova, IonicNativePlugin, Plugin } from '@ionic-native/core';
  * ...
  *
  * this.uptime.getUptime()
- *   .then((uptime: any) => console.log(uptime))
+ *   .then((uptime: string) => console.log(uptime))
  *   .catch((error: any) => console.log(error));
  *
  * ```
@@ -27,7 +27,7 @@ import { Cordova, IonicNativePlugin, Plugin } from '@ionic-native/core';
   repo: 'https://github.com/s1lviu/cordova-plugin-uptime',
   install: '',
   installVariables: [],
-  platforms: ['Android']
+  platforms: ['Android', 'iOS']
 })
 @Injectable()
 export class Uptime extends IonicNativePlugin {


### PR DESCRIPTION
Added iOS support.

How can we change this page?
https://ionicframework.com/docs/native/uptime/

The installation does not contain the cordova plugin installation (ionic cordova plugin add cordova-plugin-uptime)

Thanks!
