### PR TITLE
feat(plugin): Add google nearby plugin

### DIFF
--- a/src/@ionic-native/plugins/google-nearby/index.ts
+++ b/src/@ionic-native/plugins/google-nearby/index.ts
@@ -27,7 +27,7 @@ import { Observable } from 'rxjs/Observable';
   pluginName: 'GoogleNearby',
   plugin: 'cordova-plugin-google-nearby',
   pluginRef: 'window.nearby',
-  repo: 'https://github.com/hahahannes/googlenearby-cordova-plugin',
+  repo: 'https://github.com/hahahannes/cordova-plugin-google-nearby',
   install: 'ionic cordova plugin add cordova-plugin-google-nearby --variable API_KEY="123456789"',
   installVariables: ['API_KEY'],
   platforms: ['Android']
@@ -56,14 +56,4 @@ export class GoogleNearby extends IonicNativePlugin {
   subscribe(): Observable<any> {
     return;
   }
-
-/**
-   * Unsubscribe from Messages
-   * @return {Promise<any>} Returns a promise that resolves when you unsubscribed
-   */
-  @Cordova()
-  unsubscribe(): Promise<any> {
-    return;
-  }
-
 }

--- a/src/@ionic-native/plugins/google-nearby/index.ts
+++ b/src/@ionic-native/plugins/google-nearby/index.ts
@@ -1,0 +1,69 @@
+import { Injectable } from '@angular/core';
+import { Plugin, Cordova, IonicNativePlugin } from '@ionic-native/core';
+import { Observable } from 'rxjs/Observable';
+
+/**
+ * @name google-nearby
+ * @description
+ * This plugin adds support for the Google Nearby Messages API.
+ *
+ * @usage
+ * ```typescript
+ * import { GoogleNearby } from '@ionic-native/google-nearby';
+ *
+ *
+ * constructor(private googleNearby: GoogleNearby) { }
+ *
+ * this.googleNearby.publish('Hello')
+ *   .then((res: any) => console.log(res))
+ *   .catch((error: any) => console.error(error));
+ * 
+ * this.googleNearby.subscribe()
+ *   .then((res: any) => console.log(res))
+ *   .catch((error: any) => console.error(error));
+ * ```
+ */
+@Plugin({
+  pluginName: 'GoogleNearby',
+  plugin: 'cordova-plugin-google-nearby',
+  pluginRef: 'window.nearby',
+  repo: 'https://github.com/hahahannes/googlenearby-cordova-plugin',
+  install: 'ionic cordova plugin add cordova-plugin-google-nearby --variable API_KEY="123456789"',
+  installVariables: ['API_KEY'],
+  platforms: ['Android']
+})
+@Injectable()
+export class GoogleNearby extends IonicNativePlugin {
+
+  /**
+   * Publish a message
+   * @param message {string} Message to publish
+   * @return {Promise<any>} Returns a promise that resolves when the message got published
+   */
+  @Cordova()
+  publish(message: string): Promise<any> {
+    return;
+  }
+
+/**
+   * Subscribe to recieve messages
+   * @return {Observable<any>} Returns an observable that emits recieved messages
+   */
+  @Cordova({
+    observable: true,
+    clearFunction: 'unsubscribe'
+  })
+  subscribe(): Observable<any> {
+    return;
+  }
+
+/**
+   * Unsubscribe from Messages
+   * @return {Promise<any>} Returns a promise that resolves when you unsubscribed
+   */
+  @Cordova()
+  unsubscribe(): Promise<any> {
+    return;
+  }
+
+}


### PR DESCRIPTION
Hi, I would like to merge a new plugin that wraps [this cordova plugin ](https://github.com/hahahannes/cordova-plugin-google-nearby) with support for the Google Nearby API. At the moment it only supports android and the Messages API not the Connections API.

Thanks!
Hannes