### PR TITLE
Fix v5 imports

### DIFF
--- a/scripts/build/transformers/imports.ts
+++ b/scripts/build/transformers/imports.ts
@@ -19,7 +19,9 @@ function transformImports(file: ts.SourceFile, ctx: ts.TransformationContext, ng
 
   const decoratorRegex: RegExp = /@([a-zA-Z]+)\(/g;
 
-  const ignored: string [] = ['Plugin', 'Component'];
+  const ignored: string [] = ['Plugin', 'Component', 'Injectable'];
+
+  const keep: string [] = ['getPromise'];
 
   let m;
 
@@ -37,15 +39,18 @@ function transformImports(file: ts.SourceFile, ctx: ts.TransformationContext, ng
 
     importStatement.importClause.namedBindings.elements = [
       ts.createIdentifier('IonicNativePlugin'),
-      ...methods.map(m => ts.createIdentifier(m))
+      ...methods.map(m => ts.createIdentifier(m)),
+      ...importStatement.importClause.namedBindings.elements.filter(el => keep.indexOf(el.name.text) !== -1)
     ];
 
     if (ngcBuild) {
       importStatement.importClause.namedBindings.elements = importStatement.importClause.namedBindings.elements.map(
         binding => {
-          binding.name = {
-            text: binding.escapedText
-          };
+          if (binding.escapedText) {
+            binding.name = {
+              text: binding.escapedText
+            };
+          }
           return binding;
         }
       );


### PR DESCRIPTION
Imports in v5 are broken, for example in ```file``` plugin : 

```ts
import { IonicNativePlugin, checkAvailability, cordovaPropertyGet, cordovaPropertySet, injectable } from '@ionic-native/core';
```

which is wrong because ```injectable``` is not exported by ionic-native/core and also because the ```getPromise``` function import is removed from the original file which break some functionalities.

It should be : 

```ts
import { IonicNativePlugin, checkAvailability, cordovaPropertyGet, cordovaPropertySet, getPromise } from '@ionic-native/core';
```

I am not sure about what is the right way to fix it but the changes I have done here seems to do the job.