### PR TITLE
docs(camera): Update docs to advise against DATA_URL

### DIFF
--- a/src/@ionic-native/plugins/camera/index.ts
+++ b/src/@ionic-native/plugins/camera/index.ts
@@ -7,7 +7,7 @@ export interface CameraOptions {
   /**
    * Choose the format of the return value.
    * Defined in Camera.DestinationType. Default is FILE_URI.
-   *      DATA_URL : 0,   Return image as base64-encoded string,
+   *      DATA_URL : 0,   Return image as base64-encoded string (DATA_URL can be very memory intensive and cause app crashes or out of memory errors. Use FILE_URI or NATIVE_URI if possible),
    *      FILE_URI : 1,   Return image file URI,
    *      NATIVE_URI : 2  Return image native URI
    *          (e.g., assets-library:// on iOS or content:// on Android)
@@ -139,14 +139,14 @@ export enum Direction {
  *
  * const options: CameraOptions = {
  *   quality: 100,
- *   destinationType: this.camera.DestinationType.DATA_URL,
+ *   destinationType: this.camera.DestinationType.FILE_URI,
  *   encodingType: this.camera.EncodingType.JPEG,
  *   mediaType: this.camera.MediaType.PICTURE
  * }
  *
  * this.camera.getPicture(options).then((imageData) => {
  *  // imageData is either a base64 encoded string or a file URI
- *  // If it's base64:
+ *  // If it's base64 (DATA_URL):
  *  let base64Image = 'data:image/jpeg;base64,' + imageData;
  * }, (err) => {
  *  // Handle error


### PR DESCRIPTION
DATA_URL can be very memory intensive and cause app crashes or out of memory errors.
Use FILE_URI or NATIVE_URI if possible