### PR TITLE
docs(android-full-screen): edit example

### DIFF
--- a/src/@ionic-native/plugins/android-full-screen/index.ts
+++ b/src/@ionic-native/plugins/android-full-screen/index.ts
@@ -44,7 +44,7 @@ export enum AndroidSystemUiFlags {
  *
  * this.androidFullScreen.isImmersiveModeSupported()
  *   .then(() => console.log('Immersive mode supported'))
- *   .catch(err => console.log(error));
+ *   .catch(err => console.log(err));
  *
  * ```
  */


### PR DESCRIPTION
Variable "error" doesn't exsit in the catch.

`this.androidFullScreen.isImmersiveModeSupported()
  .then(() => console.log('Immersive mode supported'))
  .catch(err => console.log(error));`

to

`this.androidFullScreen.isImmersiveModeSupported()
  .then(() => console.log('Immersive mode supported'))
  .catch(err => console.log(err));`

