### PR TITLE
fix(web-intent): registerBroadcastReceiver as Observable

### DIFF
--- a/src/@ionic-native/plugins/web-intent/index.ts
+++ b/src/@ionic-native/plugins/web-intent/index.ts
@@ -197,10 +197,10 @@ export class WebIntent extends IonicNativePlugin {
    * @returns {Observable<any>}
    */
   @Cordova({ 
-	observable: true 
+    observable: true
   })
   registerBroadcastReceiver(filters: any): Observable<any> {
-	  return;
+    return;
   }
 
   /**

--- a/src/@ionic-native/plugins/web-intent/index.ts
+++ b/src/@ionic-native/plugins/web-intent/index.ts
@@ -194,9 +194,14 @@ export class WebIntent extends IonicNativePlugin {
   /**
    * Registers a broadcast receiver for the specified filters
    * @param filters {any}
+   * @returns {Observable<any>}
    */
-  @Cordova({ sync: true })
-  registerBroadcastReceiver(filters: any): void {}
+  @Cordova({ 
+	observable: true 
+  })
+  registerBroadcastReceiver(filters: any): Observable<any> {
+	  return;
+  }
 
   /**
    * Unregisters a broadcast receiver

--- a/src/@ionic-native/plugins/web-intent/index.ts
+++ b/src/@ionic-native/plugins/web-intent/index.ts
@@ -196,7 +196,7 @@ export class WebIntent extends IonicNativePlugin {
    * @param filters {any}
    * @returns {Observable<any>}
    */
-  @Cordova({ 
+  @Cordova({
     observable: true
   })
   registerBroadcastReceiver(filters: any): Observable<any> {


### PR DESCRIPTION
…n provides no way to receive the registered broadcasts.

Usage is as follows:
webintent.registerBroadcastReceiver({
      filterActions: [
        'com.example.ACTION'
      ],
      filterCategories: [
        'android.intent.category.DEFAULT'
      ]
    }).subscribe((intent) => {console.log('Received Intent: ' + JSON.stringify(intent.extras));});