### PR TITLE
feat(send-result): add sendResult method for WebIntent plugin

### DIFF
--- a/src/@ionic-native/plugins/web-intent/index.ts
+++ b/src/@ionic-native/plugins/web-intent/index.ts
@@ -216,4 +216,14 @@ export class WebIntent extends IonicNativePlugin {
   getIntent(): Promise<any> {
     return;
   }
+
+  /**
+   * Send a result back to the Intent that started this Activity.
+   * The data can be passed using 'extras'.
+   * @returns {Promise<any>}
+   */
+  @Cordova()
+  sendResult({ extras: {}}): Promise<any> {
+    return;
+  }
 }


### PR DESCRIPTION
The `sendResult` method is missing in the Ionic Native definition. 

The definition in the Cordova plugin can be found here:
https://github.com/darryncampbell/darryncampbell-cordova-plugin-intent/blob/master/www/IntentShim.js#L77

The Java implementation is defined here:
https://github.com/darryncampbell/darryncampbell-cordova-plugin-intent/blob/master/src/android/IntentShim.java#L219