### PR TITLE
docs(file): fix example

### DIFF
--- a/src/@ionic-native/plugins/file/index.ts
+++ b/src/@ionic-native/plugins/file/index.ts
@@ -654,7 +654,7 @@ declare const window: Window;
  *
  * ...
  *
- * this.file.checkDir(this.file.dataDirectory, 'mydir').then(_ => console.log('Directory exists')).catch(err => console.log('Directory doesn't exist'));
+ * this.file.checkDir(this.file.dataDirectory, 'mydir').then(_ => console.log('Directory exists')).catch(err => console.log('Directory doesn\'t exist'));
  *
  * ```
  *


### PR DESCRIPTION
`doesn't` was using a non escaped single quote. Therefore the example will not work and the highlighting in the demo page is broken.

![image](https://user-images.githubusercontent.com/13085980/39819185-2000987a-53a3-11e8-899f-9cca1ea27380.png)
