### PR TITLE
stop transforming "declare" classes in v5

### DIFF
--- a/scripts/build/transformers/plugin-class.ts
+++ b/scripts/build/transformers/plugin-class.ts
@@ -57,7 +57,8 @@ function transformClasses(
   return ts.visitEachChild(
     file,
     node => {
-      if (node.kind !== ts.SyntaxKind.ClassDeclaration) {
+      if (node.kind !== ts.SyntaxKind.ClassDeclaration
+          || (node.modifiers && node.modifiers.find(v => v.kind === ts.SyntaxKind.DeclareKeyword))) {
         return node;
       }
       return transformClass(node, ngcBuild);


### PR DESCRIPTION
This PR fixes a wrong behaviour in v5 which transform "declare" classes to real classes.

For example the ```file``` plugin declare a class like this : 
```ts
export declare class FileReader {
   ...
}
```
and currently in the final ```file``` plugin package, v5 turns it into this : 
```js
var FileReader = /** @class */ (function () {
    function FileReader() {
    }
    return FileReader;
}());
export { FileReader };
``` 
which is wrong because FileReader should come from ```cordova-plugin-file```. 

