### PR TITLE
fix(OSNotification) can't create notifications

### DIFF
--- a/src/@ionic-native/plugins/onesignal/index.ts
+++ b/src/@ionic-native/plugins/onesignal/index.ts
@@ -6,11 +6,11 @@ export interface OSNotification {
   /**
    * Was app in focus.
    */
-  isAppInFocus: boolean;
+  isAppInFocus?: boolean;
   /**
    * Was notification shown to the user. Will be false for silent notifications.
    */
-  shown: boolean;
+  shown?: boolean;
   /**
    * **ANDROID** - Android Notification assigned to the notification. Can be used to cancel or replace the notification.
    */
@@ -18,17 +18,17 @@ export interface OSNotification {
   /**
    * Payload received from OneSignal.
    */
-  payload: OSNotificationPayload;
+  payload?: OSNotificationPayload;
   /**
    * How the notification was displayed to the user. Can be set to `Notification`, `InAppAlert`, or `None` if it was not displayed.
    */
-  displayType: OSDisplayType;
+  displayType?: OSDisplayType;
   /**
    * **ANDROID** - Notification is a summary notification for a group this will contain all notification payloads it was created from.
    */
   groupedNotifications?: OSNotificationPayload[];
   app_id?: string;
-  contents: any;
+  contents?: any;
   headings?: any;
   isIos?: boolean;
   isAndroid?: boolean;


### PR DESCRIPTION
Made all properties in OSNotification optional because when you create a push notification the type is OSNotification but it does not have all the same properties required as the OSNotification as a response from a received notification. For example, you don't pass in isAppInFocus when you create a notification but it was causing issues when trying to post a notification because it was showing as required because OSNotification as a response will always have isAppInFocus.