### PR TITLE
docs(navigation-bar): fix typo

### DIFF
--- a/src/@ionic-native/plugins/navigation-bar/index.ts
+++ b/src/@ionic-native/plugins/navigation-bar/index.ts
@@ -6,7 +6,7 @@ import { Cordova, Plugin, IonicNativePlugin } from '@ionic-native/core';
  * @beta
  * @name Navigation Bar
  * @description
- * The NavigationBar plugin can you to hide and auto hide the android navigation bar.
+ * The NavigationBar plugin allows you to hide and auto hide the android navigation bar.
  *
  * @usage
  * ```typescript


### PR DESCRIPTION
Hey!

A small misspelling detected here 🙂

This:

> The NavigationBar plugin **can** you to hide and auto hide the android navigation bar.

Should be:

> The NavigationBar plugin **allows** you to hide and auto hide the android navigation bar.