### PR TITLE
fix(themeable-browser): allow hidden and clear cache

### DIFF
--- a/src/@ionic-native/plugins/themeable-browser/index.ts
+++ b/src/@ionic-native/plugins/themeable-browser/index.ts
@@ -48,9 +48,9 @@ export interface ThemeableBrowserOptions {
 
   // inAppBrowser options
   location?: string;
-  hidden?: string;
-  clearcache?: string;
-  clearsessioncache?: string;
+  hidden?: boolean;
+  clearcache?: boolean;
+  clearsessioncache?: boolean;
   zoom?: string;
   hardwareback?: string;
   mediaPlaybackRequiresUserAction?: string;


### PR DESCRIPTION
it wrong from boolean to string, after 1 year i update it. already test many time.

clear for issue: [ThemeableBrowser cannot hidden and clear cache](https://github.com/ionic-team/ionic-native/issues/2521)

closes: #2521