### PR TITLE
fix v5 imports for file-transfer plugin

### DIFF
--- a/scripts/build/transformers/imports.ts
+++ b/scripts/build/transformers/imports.ts
@@ -21,7 +21,7 @@ function transformImports(file: ts.SourceFile, ctx: ts.TransformationContext, ng
 
   const ignored: string [] = ['Plugin', 'Component', 'Injectable'];
 
-  const keep: string [] = ['getPromise'];
+  const keep: string [] = ['getPromise', 'checkAvailability'];
 
   let m;
 


### PR DESCRIPTION
Imports in v5 are broken for file-transfer plugin, for example : 

```ts
import { IonicNativePlugin, instanceAvailability, cordovaInstance } from '@ionic-native/core';
```

which is wrong because the ```checkAvailability``` function import is removed from the original file which break FileTransferObject constructor.

It should be : 

```ts
import { IonicNativePlugin, instanceAvailability, cordovaInstance, checkAvailability } from '@ionic-native/core';
```
