### PR TITLE
fix(background-geolocation): watchLocationMode returns observable

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ionic-native",
-  "version": "4.7.1-beta.1",
+  "version": "4.7.0",
   "description": "Native plugin wrappers for Cordova and Ionic with TypeScript, ES6+, Promise and Observable support",
   "homepage": "https://ionicframework.com/",
   "author": "Ionic Team <hi@ionic.io> (https://ionic.io)",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ionic-native",
-  "version": "4.7.0",
+  "version": "4.7.1-beta.1",
   "description": "Native plugin wrappers for Cordova and Ionic with TypeScript, ES6+, Promise and Observable support",
   "homepage": "https://ionicframework.com/",
   "author": "Ionic Team <hi@ionic.io> (https://ionic.io)",

--- a/src/@ionic-native/plugins/background-geolocation/index.ts
+++ b/src/@ionic-native/plugins/background-geolocation/index.ts
@@ -459,12 +459,13 @@ export class BackgroundGeolocation extends IonicNativePlugin {
    * Method can be used to detect user changes in location services settings.
    * If user enable or disable location services then success callback will be executed.
    * In case or error (SettingNotFoundException) fail callback will be executed.
-   * @returns {Promise<boolean>}
+   * @returns {Observable<number>}
    */
   @Cordova({
-    platforms: ['Android']
+    platforms: ['Android'],
+    observable: true
   })
-  watchLocationMode(): Promise<boolean> { return; }
+  watchLocationMode(): Observable<number> { return; }
 
   /**
    * Stop watching for location mode changes.


### PR DESCRIPTION
# Background Geolocation `watchLocationMode` Observable
Plugin has a method to watch location mode: `watchLocationMode`.
Currently it is declared as returning a Promise. That means the callback is only called ones.

Since this is a listener that is called multiple times from the native part of the plugin it has to be declared to return an observable that can be subscribed.