### PR TITLE
fix(healths): add missing attribute on HealthQueryOptionsAggregated

### DIFF
--- a/src/@ionic-native/plugins/health/index.ts
+++ b/src/@ionic-native/plugins/health/index.ts
@@ -76,6 +76,12 @@ export interface HealthQueryOptionsAggregated {
    * supported values are: 'hour', 'day', 'week', 'month', 'year'.
    */
   bucket: string;
+
+  /**
+   * In Android, it is possible to query for "raw" steps or to select those as filtered by the Google Fit app.
+   * In the latter case the query object must contain the field filtered: true.
+   */
+  filtered?: boolean;
 }
 
 /**


### PR DESCRIPTION
Adding missing "filtered" attribute on HealthQueryOptionsAggregated object. 

It has been added to the cordova-plugin-health (https://github.com/dariosalvi78/cordova-plugin-health/blob/master/src/android/HealthPlugin.java => line 1248 is where it is used), but not yet in the ionic-native part. 

Also already existing for the regular HealthQueryOptions object in ionic-native