### PR TITLE
feat(photo-library): maxItems to limit items-iOS

### DIFF
--- a/src/@ionic-native/plugins/photo-library/index.ts
+++ b/src/@ionic-native/plugins/photo-library/index.ts
@@ -252,6 +252,7 @@ export interface GetLibraryOptions {
   chunkTimeSec?: number;
   useOriginalFileNames?: boolean;
   includeAlbumData?: boolean;
+  maxItems?: number;
 }
 
 /**


### PR DESCRIPTION
I have submitted a pull request to the plugin author awaiting merge.  This will limit the number of items returned. ios only