### PR TITLE
docs(card-io): fix example

### DIFF
--- a/src/@ionic-native/plugins/card-io/index.ts
+++ b/src/@ionic-native/plugins/card-io/index.ts
@@ -157,7 +157,7 @@ export interface CardIOResponse {
  *           requireCVV: false,
  *           requirePostalCode: false
  *         };
- *         CardIO.scan(options);
+ *         this.cardIO.scan(options);
  *       }
  *     }
  *   );


### PR DESCRIPTION
 Property 'scan' does not exist on type 'typeof CardIO'