### PR TITLE
fix(onesignal): update OSPermissionState interface

### DIFF
--- a/src/@ionic-native/plugins/onesignal/index.ts
+++ b/src/@ionic-native/plugins/onesignal/index.ts
@@ -229,9 +229,13 @@ export interface OSPermissionState {
    */
   hasPrompted: boolean;
   /**
-   * Permissions Status
+   * Permissions Status (iOS Only)
    */
   status: any;
+  /**
+   * Permissions State (Android Only)
+   */
+  state: any;
 }
 /**
  * OSSubscriptionState


### PR DESCRIPTION
Plugin: onesignal

Description: 
Adding 'state' property to 'OSPermissionState' interface because whenever I try to compile it fails with the following message: --- Property 'state' does not exist on type 'OSPermissionState' --- 

I check the documentation of the onesignal-cordova-plugin in here: https://documentation.onesignal.com/docs/cordova-sdk#section--getpermissionsubscriptionstate- and it saids that the OSPermissionState should have a 'status' property when platform is ios and a 'state' property when platform is android however the interface only specify the 'hasPrompted' and 'status' properties.