### PR TITLE
fix(healt): add correct return type for query function

### DIFF
--- a/src/@ionic-native/plugins/health/index.ts
+++ b/src/@ionic-native/plugins/health/index.ts
@@ -241,7 +241,7 @@ export class Health extends IonicNativePlugin {
    * been given at some point in the past.
    *
    * Quirks of requestAuthorization()
-
+   *
    * In Android, it will try to get authorization from the Google Fit APIs.
    * It is necessary that the app's package name and the signing key are registered in the Google API console.
    * In Android, be aware that if the activity is destroyed (e.g. after a rotation) or is put in background,
@@ -298,7 +298,7 @@ export class Health extends IonicNativePlugin {
    * nutrition.vitamin_a is given in micrograms in HealthKit and International Unit in Google Fit.
    * Automatic conversion is not trivial and depends on the actual substance.
    *
-   * @param queryOptions {HealthQueryOptions}
+   * @param {HealthQueryOptions} queryOptions
    * @return {Promise<HealthData[]>}
    */
   @Cordova()
@@ -322,7 +322,7 @@ export class Health extends IonicNativePlugin {
    * To be sure to get all the stored quantities, it's better to query single nutrients.
    * nutrition.vitamin_a is given in micrograms in HealthKit and International Unit in Google Fit.
    *
-   * @param queryOptionsAggregated {HealthQueryOptionsAggregated}
+   * @param {HealthQueryOptionsAggregated} queryOptionsAggregated
    * @return {Promise<HealthData[]>}
    */
   @Cordova()

--- a/src/@ionic-native/plugins/health/index.ts
+++ b/src/@ionic-native/plugins/health/index.ts
@@ -299,10 +299,10 @@ export class Health extends IonicNativePlugin {
    * Automatic conversion is not trivial and depends on the actual substance.
    *
    * @param queryOptions {HealthQueryOptions}
-   * @return {Promise<HealthData>}
+   * @return {Promise<HealthData[]>}
    */
   @Cordova()
-  query(queryOptions: HealthQueryOptions): Promise<HealthData> { return; }
+  query(queryOptions: HealthQueryOptions): Promise<HealthData[]> { return; }
 
   /**
    * Gets aggregated data in a certain time window. Usually the sum is returned for the given quantity.


### PR DESCRIPTION
query method is always returning an array

closes: #2499