### PR TITLE
docs(deeplinks): update example

### DIFF
--- a/src/@ionic-native/plugins/deeplinks/index.ts
+++ b/src/@ionic-native/plugins/deeplinks/index.ts
@@ -45,12 +45,12 @@ export interface DeeplinkOptions {
  *      '/about-us': AboutPage,
  *      '/universal-links-test': AboutPage,
  *      '/products/:productId': ProductPage
- *    }).subscribe((match) => {
+ *    }).subscribe(match => {
  *      // match.$route - the route we matched, which is the matched entry from the arguments to route()
  *      // match.$args - the args passed in the link
  *      // match.$link - the full link data
  *      console.log('Successfully matched route', match);
- *    }, (nomatch) => {
+ *    }, nomatch => {
  *      // nomatch.$link - the full link data
  *      console.error('Got a deeplink that didn\'t match', nomatch);
  *    });
@@ -63,12 +63,12 @@ export interface DeeplinkOptions {
  * this.deeplinks.routeWithNavController(this.navController, {
  *   '/about-us': AboutPage,
  *   '/products/:productId': ProductPage
- * }).subscribe((match) => {
+ * }).subscribe(match => {
  *     // match.$route - the route we matched, which is the matched entry from the arguments to route()
  *     // match.$args - the args passed in the link
  *     // match.$link - the full link data
  *     console.log('Successfully matched route', match);
- *   }, (nomatch) => {
+ *   }, nomatch => {
  *     // nomatch.$link - the full link data
  *     console.error('Got a deeplink that didn\'t match', nomatch);
  *   });


### PR DESCRIPTION
If it has only one argument, then no need function brackets. It would decrease the readability of the source code snippets.