### PR TITLE
docs(sqlite): Add interface for transaction callback function argument

### DIFF
--- a/src/@ionic-native/plugins/sqlite/index.ts
+++ b/src/@ionic-native/plugins/sqlite/index.ts
@@ -36,14 +36,20 @@ export interface SQLiteDatabaseConfig {
 /**
  * @hidden
  */
-export interface SQLiteTransaction {
-  start: () => void;
+export interface DbTransaction {
   executeSql: (
-    sql: any,
-    values: any,
-    success: Function,
-    error: Function
-  ) => void;
+      sql: any,
+      values: any,
+      success: Function,
+      error: Function
+    ) => void;
+}
+
+/**
+ * @hidden
+ */
+export interface SQLiteTransaction extends DbTransaction {
+  start: () => void;
   addStatement: (
     sql: any,
     values: any,
@@ -74,14 +80,14 @@ export class SQLiteObject {
   addTransaction(transaction: (tx: SQLiteTransaction) => void): void {}
 
   /**
-   * @param fn {any}
+   * @param fn {Function}
    * @returns {Promise<any>}
    */
   @CordovaInstance({
     successIndex: 2,
     errorIndex: 1
   })
-  transaction(fn: any): Promise<any> {
+  transaction(fn: (tx: DbTransaction) => void): Promise<any> {
     return;
   }
 


### PR DESCRIPTION
The transaction callback function argument is currently typed as `any`, however this isn't very  helpful so I have added a base interface which contains only the `executeSql` function. This function is all that is available on the object returned by WebSQL, but is also available on the full SQLite implementation.