### PR TITLE
feat(network-interface): match latest plugin release

### DIFF
--- a/src/@ionic-native/plugins/network-interface/index.ts
+++ b/src/@ionic-native/plugins/network-interface/index.ts
@@ -10,15 +10,21 @@ import { Plugin, Cordova, IonicNativePlugin } from '@ionic-native/core';
  * ```typescript
  * import { NetworkInterface } from '@ionic-native/network-interface';
  *
+ * constructor( private networkInterface: NetworkInterface ) {
  *
- * constructor(private networkInterface: NetworkInterface) { }
+ *   this.networkInterface.getWiFiIPAddress()
+ *     .then(address => console.info(`IP: ${address.ip}, Subnet: ${address.subnet}`))
+ *     .catch(error => console.error(`Unable to get IP: ${error}`));
  *
- * ...
+ *   this.networkInterface.getCarrierIPAddress() {
+ *     .then(address => console.info(`IP: ${address.ip}, Subnet: ${address.subnet}`))
+ *     .catch(error => console.error(`Unable to get IP: ${error}`));
  *
- * this.networkInterface.getWiFiIPAddress(function (ip) { alert(ip); });
- * this.networkInterface.getCarrierIPAddress(function (ip) { alert(ip); });
- *
- *
+ *   const url = 'www.github.com';
+ *   this.networkInterface.getHttpProxyInformation(url)
+ *     .then(proxy => console.info(`Type: ${proxy.type}, Host: ${proxy.host}, Port: ${proxy.port}`))
+ *     .catch(error => console.error(`Unable to get proxy info: ${error}`));
+ * }
  * ```
  */
 @Plugin({
@@ -31,28 +37,32 @@ import { Plugin, Cordova, IonicNativePlugin } from '@ionic-native/core';
 @Injectable()
 export class NetworkInterface extends IonicNativePlugin {
 
-  @Cordova()
-  getIPAddress(): Promise<string> {
-    return;
-  }
-
   /**
    * Gets the WiFi IP address
-   * @param success {Function} Callback used when successful
-   * @param error {Function} Callback used when failure
+   * @return {Promise<any>} Returns a Promise that resolves with the IP address information.
    */
   @Cordova()
-  getWiFiIPAddress(): Promise<string> {
+  getWiFiIPAddress(): Promise<any> {
     return;
   }
 
   /**
    * Gets the wireless carrier IP address
-   * @param success {Function} Callback used when successful
-   * @param error {Function} Callback used when failure
+   * @return {Promise<any>} Returns a Promise that resolves with the IP address information.
    */
   @Cordova()
-  getCarrierIPAddress(): Promise<string> {
+  getCarrierIPAddress(): Promise<any> {
     return;
   }
+
+  /**
+   * Gets the relevant proxies for the passed URL in order of application
+   * @param {url} message  The message to display.
+   * @return {Promise<any>} Returns a Promise that resolves with the proxy information.
+   */
+  @Cordova()
+  getHttpProxyInformation(url: string): Promise<any> {
+    return;
+  }
+
 }


### PR DESCRIPTION
As currently implemented, this wrapper doesn't work for all underlying platform implementations (certainly not on Android, because the Promise resolves to an object, not a string).

I've changed the types to `any` here in the interest of simplicity. I've also updated the associated documentation in a PR against the plugin implementation repo (https://github.com/salbahra/cordova-plugin-networkinterface).

closes: #2472