### PR TITLE
fix(sqlite): mark optional arguments for executeSql

### DIFF
--- a/src/@ionic-native/plugins/sqlite/index.ts
+++ b/src/@ionic-native/plugins/sqlite/index.ts
@@ -38,11 +38,11 @@ export interface SQLiteDatabaseConfig {
  */
 export interface DbTransaction {
   executeSql: (
-      sql: any,
-      values: any,
-      success: Function,
-      error: Function
-    ) => void;
+    sql: any,
+    values?: any[],
+    success?: Function,
+    error?: Function
+  ) => void;
 }
 
 /**
@@ -50,12 +50,7 @@ export interface DbTransaction {
  */
 export interface SQLiteTransaction extends DbTransaction {
   start: () => void;
-  addStatement: (
-    sql: any,
-    values: any,
-    success: Function,
-    error: Function
-  ) => void;
+  addStatement: DbTransaction['executeSql'];
   handleStatementSuccess: (handler: Function, response: any) => void;
   handleStatementFailure: (handler: Function, response: any) => void;
   run: () => void;
@@ -126,7 +121,7 @@ export class SQLiteObject {
    * ensure it resolved and successfully opened the database.
    */
   @CordovaInstance()
-  executeSql(statement: string, params: any): Promise<any> {
+  executeSql(statement: string, params?: any[]): Promise<any> {
     return;
   }
 


### PR DESCRIPTION
With the recent addition in 713efd720626c68df9a4c8a902eca85bb6dda1eb one of my apps broke since the optional arguments were not marked as optional. This resolves that.