### PR TITLE
feat(ccm): replace plugin source

### DIFF
--- a/src/@ionic-native/plugins/fcm/index.ts
+++ b/src/@ionic-native/plugins/fcm/index.ts
@@ -55,9 +55,9 @@ export interface NotificationData {
  */
 @Plugin({
   pluginName: 'FCM',
-  plugin: 'cordova-plugin-fcm',
+  plugin: 'cordova-plugin-fcm-with-dependecy-updated',
   pluginRef: 'FCMPlugin',
-  repo: 'https://github.com/fechanique/cordova-plugin-fcm',
+  repo: 'https://github.com/andrehtissot/cordova-plugin-fcm-with-dependecy-updated',
   platforms: ['Android', 'iOS']
 })
 @Injectable()


### PR DESCRIPTION
The current 'cordova-plugin-fcm' returns dependency troubles and has not been maintained in a while.