### PR TITLE
fix(nfs): Optional arguments for records like textRecord

### DIFF
--- a/src/@ionic-native/plugins/nfc/index.ts
+++ b/src/@ionic-native/plugins/nfc/index.ts
@@ -291,13 +291,13 @@ export class Ndef extends IonicNativePlugin {
   record(tnf: number, type: number[] | string, id: number[] | string, payload: number[] | string): NdefRecord { return; }
 
   @Cordova({ sync: true })
-  textRecord(text: string, languageCode: string, id: number[] | string): NdefRecord { return; }
+  textRecord(text: string, languageCode?: string, id?: number[] | string): NdefRecord { return; }
 
   @Cordova({ sync: true })
-  uriRecord(uri: string, id: number[] | string): NdefRecord { return; }
+  uriRecord(uri: string, id?: number[] | string): NdefRecord { return; }
 
   @Cordova({ sync: true })
-  absoluteUriRecord(uri: string, payload: number[] | string, id: number[] | string): NdefRecord { return; }
+  absoluteUriRecord(uri: string, payload: number[] | string, id?: number[] | string): NdefRecord { return; }
 
   @Cordova({ sync: true })
   mimeMediaRecord(mimeType: string, payload: string): NdefRecord { return; }


### PR DESCRIPTION
See the cordova project [plugin sources](https://github.com/chariotsolutions/phonegap-nfc)
The attributes `id` and for textRecord `languageCode` are optional. Default language code is english (en).
