### PR TITLE
fix(user-agent): Plugin not installed

### DIFF
--- a/src/@ionic-native/plugins/user-agent/index.ts
+++ b/src/@ionic-native/plugins/user-agent/index.ts
@@ -35,7 +35,7 @@ import { Plugin, Cordova, IonicNativePlugin } from '@ionic-native/core';
 @Plugin({
   pluginName: 'UserAgent',
   plugin: 'cordova-plugin-useragent',
-  pluginRef: 'plugins.useragent',
+  pluginRef: 'UserAgent',
   repo: 'https://github.com/danielsogl/cordova-plugin-useragent',
   platforms: ['Android', 'iOS']
 })


### PR DESCRIPTION
Fixes(user-agent): plugin is not installed (https://github.com/ionic-team/ionic/issues/13870)

```
[17:33:56]  console.warn: Native: tried calling UserAgent.set, but the UserAgent plugin is not installed. 
[17:33:56]  console.warn: Install the UserAgent plugin: 'ionic cordova plugin add cordova-plugin-useragent' 
[17:33:56]  console.error: plugin_not_installed
```

Closes: (https://github.com/LouisT/cordova-useragent/issues/6) (https://github.com/ionic-team/ionic-native/issues/1789)