### PR TITLE
replace  plugin cordova-plugin-alipay

### DIFF
--- a/src/@ionic-native/plugins/alipay/index.ts
+++ b/src/@ionic-native/plugins/alipay/index.ts
@@ -6,7 +6,7 @@ import { Cordova, IonicNativePlugin, Plugin } from '@ionic-native/core';
  * @description
  * This plugin facilitates the usage of Alipay 支付宝 in an Ionic apps with the integrated AlipaySDK dated on 20180601.
  *
- * Requires Cordova plugin: `cordova-plugin-alipay-v2`. For more info, please see https://github.com/adam198824/cordova-plugin-alipay .
+ * Requires Cordova plugin: `cordova-plugin-adam-alipay`. For more info, please see https://github.com/adam198824/cordova-plugin-alipay .
  *
  * @usage
  * ```typescript
@@ -29,7 +29,7 @@ import { Cordova, IonicNativePlugin, Plugin } from '@ionic-native/core';
  */
 @Plugin({
   pluginName: 'Alipay',
-  plugin: 'cordova-plugin-alipay-v2',
+  plugin: 'cordova-plugin-adam-alipay',
   pluginRef: 'Alipay',
   repo: 'https://github.com/adam198824/cordova-plugin-alipay',
   install: 'ionic cordova plugin add cordova-plugin-alipay-v2 --variable APP_ID=your_app_id',

--- a/src/@ionic-native/plugins/alipay/index.ts
+++ b/src/@ionic-native/plugins/alipay/index.ts
@@ -32,7 +32,7 @@ import { Cordova, IonicNativePlugin, Plugin } from '@ionic-native/core';
   plugin: 'cordova-plugin-adam-alipay',
   pluginRef: 'Alipay',
   repo: 'https://github.com/adam198824/cordova-plugin-alipay',
-  install: 'ionic cordova plugin add cordova-plugin-alipay-v2 --variable APP_ID=your_app_id',
+  install: 'ionic cordova plugin add cordova-plugin-adam-alipay --variable APP_ID=your_app_id',
   installVariables: ['APP_ID'],
   platforms: ['Android', 'iOS']
 })

--- a/src/@ionic-native/plugins/alipay/index.ts
+++ b/src/@ionic-native/plugins/alipay/index.ts
@@ -6,7 +6,7 @@ import { Cordova, IonicNativePlugin, Plugin } from '@ionic-native/core';
  * @description
  * This plugin facilitates the usage of Alipay 支付宝 in an Ionic apps with the integrated AlipaySDK dated on 20180601.
  *
- * Requires Cordova plugin: `cordova-plugin-gubnoi-alipay`. For more info, please see https://github.com/jing-zhou/cordova-plugin-alipay .
+ * Requires Cordova plugin: `cordova-plugin-alipay-v2`. For more info, please see https://github.com/adam198824/cordova-plugin-alipay .
  *
  * @usage
  * ```typescript
@@ -29,10 +29,10 @@ import { Cordova, IonicNativePlugin, Plugin } from '@ionic-native/core';
  */
 @Plugin({
   pluginName: 'Alipay',
-  plugin: 'cordova-plugin-gubnoi-alipay',
+  plugin: 'cordova-plugin-alipay-v2',
   pluginRef: 'Alipay',
-  repo: 'https://github.com/jing-zhou/cordova-plugin-alipay',
-  install: 'ionic cordova plugin add cordova-plugin-gubnoi-alipay --variable APP_ID=your_app_id',
+  repo: 'https://github.com/adam198824/cordova-plugin-alipay',
+  install: 'ionic cordova plugin add cordova-plugin-alipay-v2 --variable APP_ID=your_app_id',
   installVariables: ['APP_ID'],
   platforms: ['Android', 'iOS']
 })


### PR DESCRIPTION
cordova-plugin-alipay doesn't work, I fixed this bug, but he doesn't seem to care about the problem, it didn't change, now I replace this plugin
https://github.com/adam198824/cordova-plugin-alipay