### PR TITLE
Bind listener to document instead of window

### DIFF
--- a/src/@ionic-native/plugins/network/index.ts
+++ b/src/@ionic-native/plugins/network/index.ts
@@ -89,7 +89,8 @@ export class Network extends IonicNativePlugin {
    */
   @Cordova({
     eventObservable: true,
-    event: 'offline'
+    event: 'offline',
+    element: document
   })
   onDisconnect(): Observable<any> {
     return;
@@ -101,7 +102,8 @@ export class Network extends IonicNativePlugin {
    */
   @Cordova({
     eventObservable: true,
-    event: 'online'
+    event: 'online',
+    element: document
   })
   onConnect(): Observable<any> {
     return;


### PR DESCRIPTION
We noticed that in some cases network state listeners are stopped triggering, but `navigator.onLine` still reflects the state correctly. I used the following code to debug and found out an issue with `window` and `document` difference:

```js
window.addEventListener("online", ()=>console.warn('WINDOW ONLINE'), false); // won't be triggered
window.addEventListener("offline", ()=>console.warn('WINDOW OFFLINE'), false); // won't be triggered
document.addEventListener("online", ()=>console.warn('DOCUMENT ONLINE'), false); // triggered
document.addEventListener("offline", ()=>console.warn('DOCUMENT OFFLINE'), false); // triggered
```

Also, according to plugin documentation, listeners should be bound to `document`: https://github.com/apache/cordova-plugin-network-information#offline