### PR TITLE
docs(firebase-dynamic-links): Change example

### DIFF
--- a/src/@ionic-native/plugins/firebase-dynamic-links/index.ts
+++ b/src/@ionic-native/plugins/firebase-dynamic-links/index.ts
@@ -38,10 +38,9 @@ export interface IDynamicLink {
  * constructor(private firebaseDynamicLinks: FirebaseDynamicLinks) { }
  *
  * ...
- *
+ * //Handle the logic here after opening the app with the Dynamic link
  * this.firebaseDynamicLinks.onDynamicLink()
- *   .then((res: any) => console.log(res)) //Handle the logic here after opening the app with the Dynamic link
- *   .catch((error:any) => console.log(error));
+ *   .subscribe((res: any) => console.log(res), (error:any) => console.log(error));
  * ```
  *
  * @interfaces

--- a/src/@ionic-native/plugins/firebase-dynamic-links/index.ts
+++ b/src/@ionic-native/plugins/firebase-dynamic-links/index.ts
@@ -38,7 +38,7 @@ export interface IDynamicLink {
  * constructor(private firebaseDynamicLinks: FirebaseDynamicLinks) { }
  *
  * ...
- * //Handle the logic here after opening the app with the Dynamic link
+ * // Handle the logic here after opening the app with the Dynamic link
  * this.firebaseDynamicLinks.onDynamicLink()
  *   .subscribe((res: any) => console.log(res), (error:any) => console.log(error));
  * ```


### PR DESCRIPTION
The example is a promise, but the current version uses Observables.