### PR TITLE
objectInstance properties are not being set correctly. 

### DIFF
--- a/src/@ionic-native/core/decorators/instance-property.ts
+++ b/src/@ionic-native/core/decorators/instance-property.ts
@@ -6,7 +6,7 @@ export function instancePropertyGet(pluginObj: any, key: string) {
 }
 
 export function instancePropertySet(pluginObj: any, key: string, value: any) {
-  if (pluginObj._objectInstance && pluginObj._objectInstance[key]) {
+  if (pluginObj._objectInstance) {
     pluginObj._objectInstance[key] = value;
   }
 }


### PR DESCRIPTION
The check in the `instancePropertySet` function is too aggressive.

This manifests in many plugins just not quite working right because the underlying js objects are not getting all the properties they should be getting.

