### PR TITLE
fix wrapEventObservable

### DIFF
--- a/src/@ionic-native/core/decorators/common.ts
+++ b/src/@ionic-native/core/decorators/common.ts
@@ -167,11 +167,7 @@ function wrapObservable(
  * @returns {Observable}
  */
 function wrapEventObservable(event: string, element: any): Observable<any> {
-  if (element) {
-    element = get(window, element);
-  } else {
-    element = window;
-  }
+  element = element ? get(window, element) : window;
   return fromEvent(element, event);
 }
 

--- a/src/@ionic-native/core/decorators/common.ts
+++ b/src/@ionic-native/core/decorators/common.ts
@@ -168,7 +168,7 @@ function wrapObservable(
  */
 function wrapEventObservable(event: string, element: any): Observable<any> {
   if (element) {
-    get(window, element);
+    element = get(window, element);
   } else {
     element = window;
   }


### PR DESCRIPTION
I almost sure (after some debugging) that it should fix a problem with the latest beta (5.0.0-beta.15) due to this change which have been merged : https://github.com/ionic-team/ionic-native/pull/2622 
My problem is that Network.onConnect() throws an error with the latest v5 (but worked with 5.0.0-beta.14). The error is "RangeError: Maximum call stack size exceeded" because rxjs try to subscribe to the "document" string instead of document object. 
I think it should be easy to reproduce.