### PR TITLE
[bug: 2665][open-native-settings] allow supported input

### DIFF
--- a/src/@ionic-native/plugins/open-native-settings/index.ts
+++ b/src/@ionic-native/plugins/open-native-settings/index.ts
@@ -4,8 +4,8 @@ import { Injectable } from '@angular/core';
 /**
  * @name Open Native Settings
  * @description
- * Plugin to open native screens of iOS/android settings 
- * @usage 
+ * Plugin to open native screens of iOS/android settings
+ * @usage
  * You can open any of these settings:
  * ```
  * "about", // ios
@@ -78,7 +78,7 @@ import { Injectable } from '@angular/core';
     "wifi_ip", // android
     "wifi", // ios, android
     "wireless" // android
-    ``` 
+    ```
  * ```typescript
  * import { OpenNativeSettings } from '@ionic-native/open-native-settings';
  *
@@ -102,10 +102,10 @@ export class OpenNativeSettings extends IonicNativePlugin {
 
   /**
    * Opens a setting dialog
-   * @param setting {string} setting name
+   * @param setting {string|array} setting name
    * @return {Promise<any>}
    */
   @Cordova()
-  open(setting: string): Promise<any> { return; }
+  open(setting: string | [string, boolean]): Promise<any> { return; }
 
 }


### PR DESCRIPTION
This pull request fixes issue #2665

The open-native-settings plugin doesn't allow input which is supported by the underlying Cordova-open-native-settings plugin (https://github.com/guyromb/Cordova-open-native-settings).

As the underlying plugin author explains:
> In Android, by default [Settings] is opened in the same application as a new activity… In order to open settings as a new application (two applications will appear in "recent/opened" apps list) the following code can be used: `window.cordova.plugins.settings.open(["wifi", true]); ....`

However, in `index.ts` the only accepted input is a string, making the advanced option unobtainable.

This fixes that.