### PR TITLE
fix(contacts): fixing builds

### DIFF
--- a/src/@ionic-native/plugins/contacts/index.ts
+++ b/src/@ionic-native/plugins/contacts/index.ts
@@ -1,4 +1,5 @@
 import {
+  checkAvailability,
   CordovaCheck,
   CordovaInstance,
   getPromise,


### PR DESCRIPTION
`checkAvailability()` is called in the contacts plugin without being imported and it is breaking docs builds