### PR TITLE
feat(push): Added missing voip property to IOSPushOptions

### DIFF
--- a/src/@ionic-native/plugins/push/index.ts
+++ b/src/@ionic-native/plugins/push/index.ts
@@ -111,6 +111,13 @@ export interface IOSPushOptions {
    * Action Buttons on iOS - https://github.com/phonegap/phonegap-plugin-push/blob/master/docs/PAYLOAD.md#action-buttons-1
    */
   categories?: CategoryArray;
+
+  /**
+   * If true the device will be set up to receive VoIP Push notifications and the
+   * other options will be ignored since VoIP notifications are silent
+   * notifications that should be handled in the "notification" event.
+   */
+  voip?: boolean | string;
 }
 
 export interface CategoryArray {


### PR DESCRIPTION
Been working on adding a VOIP Push Notification to my current project, and noticed it was missing this option in the IOSPushOptions. Thought I might as well help out and add it.