### PR TITLE
feat(advanced-http): Re-Add methods enableSSLPinning & acceptAllCerts

### DIFF
--- a/src/@ionic-native/plugins/http/index.ts
+++ b/src/@ionic-native/plugins/http/index.ts
@@ -179,11 +179,54 @@ export class HTTP extends IonicNativePlugin {
    * default: default SSL cert handling using system's CA certs
    * nocheck: disable SSL cert checking, trusting all certs (meant to be used only for testing purposes)
    * pinned: trust only provided certs
+   * 
+   * To use SSL pinning you must include at least one .cer SSL certificate in your app project. 
+   * You can pin to your server certificate or to one of the issuing CA certificates. 
+   * For ios include your certificate in the root level of your bundle (just add the .cer file to your project/target at the root level). 
+   * For android include your certificate in your project's platforms/android/assets folder. 
+   * In both cases all .cer files found will be loaded automatically. 
+   * If you only have a .pem certificate see this [stackoverflow answer](https://stackoverflow.com/questions/16583428/how-to-convert-an-ssl-certificate-in-linux/16583429#16583429). 
+   * You want to convert it to a DER encoded certificate with a .cer extension.
+   * 
+   * As an alternative, you can store your .cer files in the www/certificates folder.
+   * 
    * @see https://github.com/silkimen/cordova-plugin-advanced-http#setsslcertmode
    * @param {'default' | 'nocheck' | 'pinned'} mode SSL Cert handling mode
    */
   @Cordova()
   setSSLCertMode(mode: 'default' | 'nocheck' | 'pinned'): Promise<void> {
+    return;
+  }
+
+  /**
+   * Enable or disable SSL Pinning. This defaults to false.
+   *
+   * To use SSL pinning you must include at least one .cer SSL certificate in your app project.
+   * You can pin to your server certificate or to one of the issuing CA certificates.
+   * For ios include your certificate in the root level of your bundle (just add the .cer file to your project/target at the root level). 
+   * For android include your certificate in your project's platforms/android/assets folder. 
+   * In both cases all .cer files found will be loaded automatically. 
+   * If you only have a .pem certificate see this [stackoverflow answer](https://stackoverflow.com/questions/16583428/how-to-convert-an-ssl-certificate-in-linux/16583429#16583429).
+   * You want to convert it to a DER encoded certificate with a .cer extension.
+   *
+   * As an alternative, you can store your .cer files in the www/certificates folder.
+   * @deprecated This function was removed in 2.0.0. Use "setSSLCertMode" to enable SSL pinning (mode "pinned").
+   * @param enable {boolean} Set to true to enable
+   * @returns {Promise<void>} returns a promise that will resolve on success, and reject on failure
+   */
+  @Cordova()
+  enableSSLPinning(enable: boolean): Promise<void> {
+    return;
+  }
+
+  /**
+   * Accept all SSL certificates. Or disabled accepting all certificates. Defaults to false.
+   * @deprecated This function was removed in 2.0.0. Use "setSSLCertMode" to disable checking certs (mode "nocheck").
+   * @param accept {boolean} Set to true to accept
+   * @returns {Promise<void>} returns a promise that will resolve on success, and reject on failure
+   */
+  @Cordova()
+  acceptAllCerts(accept: boolean): Promise<void> {
     return;
   }
 


### PR DESCRIPTION
These two methods were removed in favour for the setSSLCertMode-method with this commit [feat(http): add setSSLCertMode function](https://github.com/ionic-team/ionic-native/commit/8db1dbef7198ffe526e747c696ac2aca0dbb6952).

They have to be back inside the code, because there is currently no release of v2.0.0 of cordova-plugin-advanced-http. I don't know how to reach @silkimen to ask for the actual release (date)...

I added the methods again with the "deprecated" mark.