### PR TITLE
feat(mixpanel): Update/add functions

### DIFF
--- a/src/@ionic-native/plugins/mixpanel/index.ts
+++ b/src/@ionic-native/plugins/mixpanel/index.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { Cordova, Plugin, IonicNativePlugin } from '@ionic-native/core';
+import { Cordova, IonicNativePlugin, Plugin } from '@ionic-native/core';
 
 declare var mixpanel: any;
 
@@ -33,7 +33,6 @@ declare var mixpanel: any;
 })
 @Injectable()
 export class Mixpanel extends IonicNativePlugin {
-
   /**
    * If originalId is omitted, aliasId will be used as originalId.
    * @param aliasId {string}
@@ -41,20 +40,26 @@ export class Mixpanel extends IonicNativePlugin {
    * @returns {Promise<any>}
    */
   @Cordova()
-  alias(aliasId: string, originalId?: string): Promise<any> { return; }
+  alias(aliasId: string, originalId?: string): Promise<any> {
+    return;
+  }
 
   /**
    *
    * @returns {Promise<any>}
    */
   @Cordova()
-  distinctId(): Promise<any> { return; }
+  distinctId(): Promise<any> {
+    return;
+  }
 
   /**
    * @returns {Promise<any>}
    */
   @Cordova()
-  flush(): Promise<any> { return; }
+  flush(): Promise<any> {
+    return;
+  }
 
   /**
    * The usePeople parameter is used for the iOS Mixpanel SDK.
@@ -63,7 +68,9 @@ export class Mixpanel extends IonicNativePlugin {
    * @returns {Promise<any>}
    */
   @Cordova()
-  identify(distinctId: string, usePeople?: boolean): Promise<any> { return; }
+  identify(distinctId: string, usePeople?: boolean): Promise<any> {
+    return;
+  }
 
   /**
    *
@@ -71,22 +78,18 @@ export class Mixpanel extends IonicNativePlugin {
    * @returns {Promise<any>}
    */
   @Cordova()
-  init(token: string): Promise<any> { return; }
+  init(token: string): Promise<any> {
+    return;
+  }
 
   /**
    *
    * @returns {Promise<any>}
    */
   @Cordova()
-  getSuperProperties(): Promise<any> { return; }
-
-  /**
-   *
-   * @param superProperties {any}
-   * @returns {Promise<any>}
-   */
-  @Cordova()
-  registerSuperProperties(superProperties: any): Promise<any> { return; }
+  getSuperProperties(): Promise<any> {
+    return;
+  }
 
   /**
    *
@@ -94,7 +97,19 @@ export class Mixpanel extends IonicNativePlugin {
    * @returns {Promise<any>}
    */
   @Cordova()
-  registerSuperPropertiesOnce(superProperties: any): Promise<any> { return; }
+  registerSuperProperties(superProperties: any): Promise<any> {
+    return;
+  }
+
+  /**
+   *
+   * @param superProperties {any}
+   * @returns {Promise<any>}
+   */
+  @Cordova()
+  registerSuperPropertiesOnce(superProperties: any): Promise<any> {
+    return;
+  }
 
   /**
    *
@@ -102,14 +117,18 @@ export class Mixpanel extends IonicNativePlugin {
    * @returns {Promise<any>}
    */
   @Cordova()
-  unregisterSuperProperty(superPropertyName: string): Promise<any> { return; }
+  unregisterSuperProperty(superPropertyName: string): Promise<any> {
+    return;
+  }
 
   /**
    *
    * @returns {Promise<any>}
    */
   @Cordova()
-  reset(): Promise<any> { return; }
+  reset(): Promise<any> {
+    return;
+  }
 
   /**
    *
@@ -117,7 +136,9 @@ export class Mixpanel extends IonicNativePlugin {
    * @returns {Promise<any>}
    */
   @Cordova()
-  timeEvent(eventName: string): Promise<any> { return; }
+  timeEvent(eventName: string): Promise<any> {
+    return;
+  }
 
   /**
    *
@@ -129,8 +150,9 @@ export class Mixpanel extends IonicNativePlugin {
     successIndex: 2,
     errorIndex: 3
   })
-  track(eventName: string, eventProperties?: any): Promise<any> { return; }
-
+  track(eventName: string, eventProperties?: any): Promise<any> {
+    return;
+  }
 }
 /**
  * @hidden
@@ -142,21 +164,24 @@ export class Mixpanel extends IonicNativePlugin {
 })
 @Injectable()
 export class MixpanelPeople extends IonicNativePlugin {
-
   /**
    *
    * @param appendObject {any}
    * @return {Promise<any>}
    */
   @Cordova()
-  append(appendObject: any): Promise<any> { return; }
+  append(appendObject: any): Promise<any> {
+    return;
+  }
 
   /**
    *
    * @return {Promise<any>}
    */
   @Cordova()
-  deleteUser(): Promise<any> { return; }
+  deleteUser(): Promise<any> {
+    return;
+  }
 
   /**
    *
@@ -164,7 +189,9 @@ export class MixpanelPeople extends IonicNativePlugin {
    * @return {Promise<any>}
    */
   @Cordova()
-  identify(distinctId: string): Promise<any> { return; }
+  identify(distinctId: string): Promise<any> {
+    return;
+  }
 
   /**
    *
@@ -172,7 +199,9 @@ export class MixpanelPeople extends IonicNativePlugin {
    * @return {Promise<any>}
    */
   @Cordova()
-  increment(peopleProperties: any): Promise<any> { return; }
+  increment(peopleProperties: any): Promise<any> {
+    return;
+  }
 
   /**
    *
@@ -180,7 +209,9 @@ export class MixpanelPeople extends IonicNativePlugin {
    * @return {Promise<any>}
    */
   @Cordova()
-  setPushId(pushId: string): Promise<any> { return; }
+  setPushId(pushId: string): Promise<any> {
+    return;
+  }
 
   /**
    *
@@ -188,7 +219,9 @@ export class MixpanelPeople extends IonicNativePlugin {
    * @return {Promise<any>}
    */
   @Cordova()
-  set(peopleProperties: any): Promise<any> { return; }
+  set(peopleProperties: any): Promise<any> {
+    return;
+  }
 
   /**
    *
@@ -196,7 +229,9 @@ export class MixpanelPeople extends IonicNativePlugin {
    * @return {Promise<any>}
    */
   @Cordova()
-  setOnce(peopleProperties: any): Promise<any> { return; }
+  setOnce(peopleProperties: any): Promise<any> {
+    return;
+  }
 
   /**
    *
@@ -205,7 +240,9 @@ export class MixpanelPeople extends IonicNativePlugin {
    * @return {Promise<any>}
    */
   @Cordova()
-  trackCharge(amount: number, chargeProperties: any): Promise<any> { return; }
+  trackCharge(amount: number, chargeProperties: any): Promise<any> {
+    return;
+  }
 
   /**
    *
@@ -213,7 +250,9 @@ export class MixpanelPeople extends IonicNativePlugin {
    * @return {Promise<any>}
    */
   @Cordova()
-  unset(propertiesArray: Array<string>): Promise<any> { return; }
+  unset(propertiesArray: Array<string>): Promise<any> {
+    return;
+  }
 
   /**
    *
@@ -221,5 +260,7 @@ export class MixpanelPeople extends IonicNativePlugin {
    * @return {Promise<any>}
    */
   @Cordova()
-  union(unionObject: any): Promise<any> { return; }
+  union(unionObject: any): Promise<any> {
+    return;
+  }
 }

--- a/src/@ionic-native/plugins/mixpanel/index.ts
+++ b/src/@ionic-native/plugins/mixpanel/index.ts
@@ -35,13 +35,13 @@ declare var mixpanel: any;
 export class Mixpanel extends IonicNativePlugin {
 
   /**
-   *
+   * If originalId is omitted, aliasId will be used as originalId.
    * @param aliasId {string}
    * @param originalId {string}
    * @returns {Promise<any>}
    */
   @Cordova()
-  alias(aliasId: string, originalId: string): Promise<any> { return; }
+  alias(aliasId: string, originalId?: string): Promise<any> { return; }
 
   /**
    *
@@ -57,12 +57,13 @@ export class Mixpanel extends IonicNativePlugin {
   flush(): Promise<any> { return; }
 
   /**
-   *
+   * The usePeople parameter is used for the iOS Mixpanel SDK.
    * @param distinctId {string}
+   * @param usePeople {boolean}
    * @returns {Promise<any>}
    */
   @Cordova()
-  identify(distinctId: string): Promise<any> { return; }
+  identify(distinctId: string, usePeople?: boolean): Promise<any> { return; }
 
   /**
    *
@@ -144,6 +145,21 @@ export class MixpanelPeople extends IonicNativePlugin {
 
   /**
    *
+   * @param appendObject {any}
+   * @return {Promise<any>}
+   */
+  @Cordova()
+  append(appendObject: any): Promise<any> { return; }
+
+  /**
+   *
+   * @return {Promise<any>}
+   */
+  @Cordova()
+  deleteUser(): Promise<any> { return; }
+
+  /**
+   *
    * @param distinctId {string}
    * @return {Promise<any>}
    */
@@ -176,10 +192,34 @@ export class MixpanelPeople extends IonicNativePlugin {
 
   /**
    *
-   * @param peopleProperties
+   * @param peopleProperties {any}
    * @return {Promise<any>}
    */
   @Cordova()
   setOnce(peopleProperties: any): Promise<any> { return; }
 
+  /**
+   *
+   * @param amount {number}
+   * @param chargeProperties
+   * @return {Promise<any>}
+   */
+  @Cordova()
+  trackCharge(amount: number, chargeProperties: any): Promise<any> { return; }
+
+  /**
+   *
+   * @param propertiesArray
+   * @return {Promise<any>}
+   */
+  @Cordova()
+  unset(propertiesArray: Array<string>): Promise<any> { return; }
+
+  /**
+   *
+   * @param unionObject {any}
+   * @return {Promise<any>}
+   */
+  @Cordova()
+  union(unionObject: any): Promise<any> { return; }
 }


### PR DESCRIPTION
- `alias` does not require an `originalId`.
- `identify` accepts a `usePeople` parameter for the iOS SDK.
- New methods:
`append`
`deleteUser`
`trackCharge`
`unset`
`union`