### PR TITLE
fix(onesignal): add missing setLocationShared method

### DIFF
--- a/src/@ionic-native/plugins/onesignal/index.ts
+++ b/src/@ionic-native/plugins/onesignal/index.ts
@@ -669,6 +669,13 @@ export class OneSignal extends IonicNativePlugin {
   setLogLevel(logLevel: { logLevel: number; visualLevel: number }): void {}
 
   /**
+   * Disable or enable location collection (Defaults to enabled) if your app has location permission.
+   * @param shared {boolean}
+   */
+  @Cordova({ sync: true })
+  setLocationShared(shared: boolean): void {}
+
+  /**
    * The passed in function will be fired when a notification permission setting changes.
    * This includes the following events:
    * - Notification permission prompt shown

--- a/src/@ionic-native/plugins/onesignal/index.ts
+++ b/src/@ionic-native/plugins/onesignal/index.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { Cordova, Plugin, IonicNativePlugin } from '@ionic-native/core';
+import { Cordova, IonicNativePlugin, Plugin } from '@ionic-native/core';
 import { Observable } from 'rxjs/Observable';
 
 export interface OSNotification {


### PR DESCRIPTION
Added this method: https://github.com/OneSignal/OneSignal-Cordova-SDK/blob/master/www/OneSignal.js#L233-L235