### PR TITLE
fix(secure-storage): add missing "getPromise" import

### DIFF
--- a/src/@ionic-native/plugins/secure-storage/index.ts
+++ b/src/@ionic-native/plugins/secure-storage/index.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { CordovaCheck, CordovaInstance, IonicNativePlugin, Plugin } from '@ionic-native/core';
+import { CordovaCheck, CordovaInstance, IonicNativePlugin, Plugin, getPromise } from '@ionic-native/core';
 
 /**
  * @hidden


### PR DESCRIPTION
Fixes error when using secure-storage plugin.

When calling `.create()` it makes a call to `getPromise`. This was not imported, and so throws an error.