### PR TITLE
fix(bluetooth-le): Removed a wrong cordova decorator param

### DIFF
--- a/src/@ionic-native/plugins/bluetooth-le/index.ts
+++ b/src/@ionic-native/plugins/bluetooth-le/index.ts
@@ -466,7 +466,7 @@ export class BluetoothLE extends IonicNativePlugin {
    * Currently the discoverable state does not have any relevance because there is no "setDiscoverable" functionality in place. That may change in the future.
    * @returns {Promise<AdapterInfo>}
    */
-  @Cordova({ callbackOrder: 'reverse', observable: true })
+  @Cordova({ callbackOrder: 'reverse' })
   getAdapterInfo(): Promise<AdapterInfo> {
     return;
   }

--- a/src/@ionic-native/plugins/bluetooth-le/index.ts
+++ b/src/@ionic-native/plugins/bluetooth-le/index.ts
@@ -668,7 +668,7 @@ export class BluetoothLE extends IonicNativePlugin {
    * @returns {Promise<OperationResult>}
    */
   @Cordova({ callbackOrder: 'reverse' })
-  read(params: DescriptorParams): Promise<{ result: OperationResult }> {
+  read(params: DescriptorParams): Promise<OperationResult> {
     return;
   }
 
@@ -678,10 +678,10 @@ export class BluetoothLE extends IonicNativePlugin {
    * Once a subscription is no longer needed, execute unsubscribe in a similar fashion.
    * The Client Configuration descriptor will automatically be written to enable notification/indication based on the characteristic's properties.
    * @param {DescriptorParams} params
-   * @returns {(Observable<{ result: OperationResult }>)}
+   * @returns {Observable<OperationResult>}
    */
   @Cordova({ callbackOrder: 'reverse', observable: true })
-  subscribe(params: DescriptorParams): Observable<{ result: OperationResult }> {
+  subscribe(params: DescriptorParams): Observable<OperationResult> {
     return;
   }
 


### PR DESCRIPTION
getAdapterInfo is a promise and had {observable: true} param