### PR TITLE
feat(in-app-browser): add missing property comments

### DIFF
--- a/src/@ionic-native/plugins/in-app-browser/index.ts
+++ b/src/@ionic-native/plugins/in-app-browser/index.ts
@@ -13,36 +13,50 @@ declare const cordova: Cordova & { InAppBrowser: any };
 export interface InAppBrowserOptions {
   /** Set to yes or no to turn the InAppBrowser's location bar on or off. */
   location?: 'yes' | 'no';
-  /** Set to yes to create the browser and load the page, but not show it. The loadstop event fires when loading is complete.
-   * Omit or set to no (default) to have the browser open and load normally. */
+  /** 
+   * Set to yes to create the browser and load the page, but not show it. The loadstop event fires when loading is complete.
+   * Omit or set to no (default) to have the browser open and load normally. 
+   */
   hidden?: 'yes' | 'no';
   /** Set to yes to have the browser's cookie cache cleared before the new window is opened. */
   clearcache?: 'yes';
   /** Set to yes to have the session cookie cache cleared before the new window is opened. */
   clearsessioncache?: 'yes';
-  /** (Android) Set to a string to use as the close button's caption instead of a X. Note that you need to localize this value yourself.
-   *  (iOS) Set to a string to use as the Done button's caption. Note that you need to localize this value yourself. */
+  /** 
+   * (Android) Set to a string to use as the close button's caption instead of a X. Note that you need to localize this value yourself.
+   * (iOS) Set to a string to use as the Done button's caption. Note that you need to localize this value yourself. 
+   */
   closebuttoncaption?: string;
-  /** (Android) Set to a valid hex color string, for example: #00ff00, and it will change the close button color from default, regardless of being a text or default X. Only has effect if user has location set to yes.
-   *  (iOS) Set as a valid hex color string, for example: #00ff00, to change from the default Done button's color. Only applicable if toolbar is not disabled. */
+  /** 
+   * (Android) Set to a valid hex color string, for example: #00ff00, and it will change the close button color from default, regardless of being a text or default X. Only has effect if user has location set to yes.
+   * (iOS) Set as a valid hex color string, for example: #00ff00, to change from the default Done button's color. Only applicable if toolbar is not disabled. 
+   */
   closebuttoncolor?: string;
   /** (Android Only) Set to yes to show Android browser's zoom controls, set to no to hide them. Default value is yes. */
   zoom?: 'yes' | 'no';
-  /** (Android & Windows Phone Only) Set to yes to use the hardware back button to navigate backwards through the InAppBrowser's history.
-   * If there is no previous page, the InAppBrowser will close. The default value is yes, so you must set it to no if you want the back button to simply close the InAppBrowser. */
+  /** 
+   * (Android & Windows Phone Only) Set to yes to use the hardware back button to navigate backwards through the InAppBrowser's history.
+   * If there is no previous page, the InAppBrowser will close. The default value is yes, so you must set it to no if you want the back button to simply close the InAppBrowser. 
+   */
   hardwareback?: 'yes' | 'no';
   /** Set to yes to prevent HTML5 audio or video from autoplaying (defaults to no). */
   mediaPlaybackRequiresUserAction?: 'yes' | 'no';
-  /** (Android) Set to yes to hide the navigation buttons on the location toolbar, only has effect if user has location set to yes. The default value is no.
-   *  (iOS) Set to yes or no to turn the toolbar navigation buttons on or off (defaults to no). Only applicable if toolbar is not disabled.*/
+  /** 
+   * (Android) Set to yes to hide the navigation buttons on the location toolbar, only has effect if user has location set to yes. The default value is no.
+   * (iOS) Set to yes or no to turn the toolbar navigation buttons on or off (defaults to no). Only applicable if toolbar is not disabled.
+   */
   hidenavigationbuttons?: 'yes' | 'no';
   /** (Android) Set to yes to hide the url bar on the location toolbar, only has effect if user has location set to yes. The default value is no.*/
   hideurlbar?: 'yes' | 'no';
-  /** (Android) Set to a valid hex color string, for example: #00ff00, and it will change the color of both navigation buttons from default. Only has effect if user has location set to yes and not hidenavigationbuttons set to yes.
-   *  (iOS) Set as a valid hex color string, for example: #00ff00, to change from the default color. Only applicable if navigation buttons are visible. */
+  /** 
+   * (Android) Set to a valid hex color string, for example: #00ff00, and it will change the color of both navigation buttons from default. Only has effect if user has location set to yes and not hidenavigationbuttons set to yes.
+   * (iOS) Set as a valid hex color string, for example: #00ff00, to change from the default color. Only applicable if navigation buttons are visible. 
+   */
   navigationbuttoncolor?: string;
-  /** (Android) Set to a valid hex color string, for example: #00ff00, and it will change the color the toolbar from default. Only has effect if user has location set to yes.
-   *  (iOS) Set as a valid hex color string, for example: #00ff00, to change from the default color of the toolbar. Only applicable if toolbar is not disabled.*/
+  /** 
+   * (Android) Set to a valid hex color string, for example: #00ff00, and it will change the color the toolbar from default. Only has effect if user has location set to yes.
+   * (iOS) Set as a valid hex color string, for example: #00ff00, to change from the default color of the toolbar. Only applicable if toolbar is not disabled.
+   */
   toolbarcolor?: string;
   /** (Android Only) Set to yes to make InAppBrowser WebView to pause/resume with the app to stop background audio (this may be required to avoid Google Play issues) */
   shouldPauseOnSuspend?: 'yes' | 'no';
@@ -58,8 +72,10 @@ export interface InAppBrowserOptions {
   toolbartranslucent?: 'yes' | 'no';
   /** (iOS Only)  Set to yes or no to prevent viewport scaling through a meta tag (defaults to no). */
   enableViewportScale?: 'yes' | 'no';
-  /** (iOS Only) Set to yes or no to allow in-line HTML5 media playback, displaying within the browser window rather than a device-specific playback interface.
-   * The HTML's video element must also include the webkit-playsinline attribute (defaults to no) */
+  /** 
+   * (iOS Only) Set to yes or no to allow in-line HTML5 media playback, displaying within the browser window rather than a device-specific playback interface.
+   * The HTML's video element must also include the webkit-playsinline attribute (defaults to no) 
+   */
   allowInlineMediaPlayback?: 'yes' | 'no';
   /** (iOS Only) Set to yes or no to open the keyboard when form elements receive focus via JavaScript's focus() call (defaults to yes). */
   keyboardDisplayRequiresUserAction?: 'yes' | 'no';
@@ -73,8 +89,10 @@ export interface InAppBrowserOptions {
   toolbarposition?: 'top' | 'bottom';
   /** (iOS Only) Set to yes or no to change the visibility of the loading indicator (defaults to no). */
   hidespinner?: 'yes' | 'no';
-  /** (Windows only) Set to yes to create the browser control without a border around it.
-   * Please note that if location=no is also specified, there will be no control presented to user to close IAB window. */
+  /** 
+   * (Windows only) Set to yes to create the browser control without a border around it.
+   * Please note that if location=no is also specified, there will be no control presented to user to close IAB window. 
+   */
   fullscreen?: 'yes';
   /** (Android Only) Sets whether the WebView should enable support for the "viewport" HTML meta tag or should use a wide viewport. When the value of the setting is no, the layout width is always set to the width of the WebView control in device-independent (CSS) pixels. When the value is yes and the page contains the viewport meta tag, the value of the width specified in the tag is used. If the page does not contain the tag or does not provide a width, then a wide viewport will be used. (defaults to yes). */
   useWideViewPort?: 'yes' | 'no';

--- a/src/@ionic-native/plugins/in-app-browser/index.ts
+++ b/src/@ionic-native/plugins/in-app-browser/index.ts
@@ -13,35 +13,35 @@ declare const cordova: Cordova & { InAppBrowser: any };
 export interface InAppBrowserOptions {
   /** Set to yes or no to turn the InAppBrowser's location bar on or off. */
   location?: 'yes' | 'no';
-  /* Set to yes to create the browser and load the page, but not show it. The loadstop event fires when loading is complete.
+  /** Set to yes to create the browser and load the page, but not show it. The loadstop event fires when loading is complete.
    * Omit or set to no (default) to have the browser open and load normally. */
   hidden?: 'yes' | 'no';
   /** Set to yes to have the browser's cookie cache cleared before the new window is opened. */
   clearcache?: 'yes';
-  /* Set to yes to have the session cookie cache cleared before the new window is opened. */
+  /** Set to yes to have the session cookie cache cleared before the new window is opened. */
   clearsessioncache?: 'yes';
-  /* (Android) Set to a string to use as the close button's caption instead of a X. Note that you need to localize this value yourself.
+  /** (Android) Set to a string to use as the close button's caption instead of a X. Note that you need to localize this value yourself.
    *  (iOS) Set to a string to use as the Done button's caption. Note that you need to localize this value yourself. */
   closebuttoncaption?: string;
-  /* (Android) Set to a valid hex color string, for example: #00ff00, and it will change the close button color from default, regardless of being a text or default X. Only has effect if user has location set to yes.
+  /** (Android) Set to a valid hex color string, for example: #00ff00, and it will change the close button color from default, regardless of being a text or default X. Only has effect if user has location set to yes.
    *  (iOS) Set as a valid hex color string, for example: #00ff00, to change from the default Done button's color. Only applicable if toolbar is not disabled. */
   closebuttoncolor?: string;
   /** (Android Only) Set to yes to show Android browser's zoom controls, set to no to hide them. Default value is yes. */
   zoom?: 'yes' | 'no';
-  /* (Android & Windows Phone Only) Set to yes to use the hardware back button to navigate backwards through the InAppBrowser's history.
+  /** (Android & Windows Phone Only) Set to yes to use the hardware back button to navigate backwards through the InAppBrowser's history.
    * If there is no previous page, the InAppBrowser will close. The default value is yes, so you must set it to no if you want the back button to simply close the InAppBrowser. */
   hardwareback?: 'yes' | 'no';
   /** Set to yes to prevent HTML5 audio or video from autoplaying (defaults to no). */
   mediaPlaybackRequiresUserAction?: 'yes' | 'no';
-  /* (Android) Set to yes to hide the navigation buttons on the location toolbar, only has effect if user has location set to yes. The default value is no.
+  /** (Android) Set to yes to hide the navigation buttons on the location toolbar, only has effect if user has location set to yes. The default value is no.
    *  (iOS) Set to yes or no to turn the toolbar navigation buttons on or off (defaults to no). Only applicable if toolbar is not disabled.*/
   hidenavigationbuttons?: 'yes' | 'no';
-  /* (Android) Set to yes to hide the url bar on the location toolbar, only has effect if user has location set to yes. The default value is no.*/
+  /** (Android) Set to yes to hide the url bar on the location toolbar, only has effect if user has location set to yes. The default value is no.*/
   hideurlbar?: 'yes' | 'no';
-  /* (Android) Set to a valid hex color string, for example: #00ff00, and it will change the color of both navigation buttons from default. Only has effect if user has location set to yes and not hidenavigationbuttons set to yes.
+  /** (Android) Set to a valid hex color string, for example: #00ff00, and it will change the color of both navigation buttons from default. Only has effect if user has location set to yes and not hidenavigationbuttons set to yes.
    *  (iOS) Set as a valid hex color string, for example: #00ff00, to change from the default color. Only applicable if navigation buttons are visible. */
   navigationbuttoncolor?: string;
-  /* (Android) Set to a valid hex color string, for example: #00ff00, and it will change the color the toolbar from default. Only has effect if user has location set to yes.
+  /** (Android) Set to a valid hex color string, for example: #00ff00, and it will change the color the toolbar from default. Only has effect if user has location set to yes.
    *  (iOS) Set as a valid hex color string, for example: #00ff00, to change from the default color of the toolbar. Only applicable if toolbar is not disabled.*/
   toolbarcolor?: string;
   /** (Android Only) Set to yes to make InAppBrowser WebView to pause/resume with the app to stop background audio (this may be required to avoid Google Play issues) */
@@ -58,7 +58,7 @@ export interface InAppBrowserOptions {
   toolbartranslucent?: 'yes' | 'no';
   /** (iOS Only)  Set to yes or no to prevent viewport scaling through a meta tag (defaults to no). */
   enableViewportScale?: 'yes' | 'no';
-  /* (iOS Only) Set to yes or no to allow in-line HTML5 media playback, displaying within the browser window rather than a device-specific playback interface.
+  /** (iOS Only) Set to yes or no to allow in-line HTML5 media playback, displaying within the browser window rather than a device-specific playback interface.
    * The HTML's video element must also include the webkit-playsinline attribute (defaults to no) */
   allowInlineMediaPlayback?: 'yes' | 'no';
   /** (iOS Only) Set to yes or no to open the keyboard when form elements receive focus via JavaScript's focus() call (defaults to yes). */
@@ -73,7 +73,7 @@ export interface InAppBrowserOptions {
   toolbarposition?: 'top' | 'bottom';
   /** (iOS Only) Set to yes or no to change the visibility of the loading indicator (defaults to no). */
   hidespinner?: 'yes' | 'no';
-  /* (Windows only) Set to yes to create the browser control without a border around it.
+  /** (Windows only) Set to yes to create the browser control without a border around it.
    * Please note that if location=no is also specified, there will be no control presented to user to close IAB window. */
   fullscreen?: 'yes';
   /** (Android Only) Sets whether the WebView should enable support for the "viewport" HTML meta tag or should use a wide viewport. When the value of the setting is no, the layout width is always set to the width of the WebView control in device-independent (CSS) pixels. When the value is yes and the page contains the viewport meta tag, the value of the width specified in the tag is used. If the page does not contain the tag or does not provide a width, then a wide viewport will be used. (defaults to yes). */


### PR DESCRIPTION
Property comments are omitted during build time, if they are not marked with double asterisks. Added missing asterisks.