### PR TITLE
refactor(network):  add enum for connection types

### DIFF
--- a/src/@ionic-native/plugins/network/index.ts
+++ b/src/@ionic-native/plugins/network/index.ts
@@ -11,6 +11,17 @@ import { merge } from 'rxjs/observable/merge';
 
 declare const navigator: any;
 
+export enum Connection {
+  UNKNOWN = 0,
+  ETHERNET,
+  WIFI,
+  CELL_2G,
+  CELL_3G ,
+  CELL_4G,
+  CELL,
+  NONE
+}
+
 /**
  * @name Network
  * @description
@@ -62,6 +73,21 @@ declare const navigator: any;
 })
 @Injectable()
 export class Network extends IonicNativePlugin {
+
+  /**
+   * Constants for possible connection types
+   */
+  Connection = {
+    UNKNOWN: 'unknown',
+    ETHERNET: 'ethernet',
+    WIFI: 'wifi',
+    CELL_2G: '2g',
+    CELL_3G: '3g',
+    CELL_4G: '4g',
+    CELL: 'cellular',
+    NONE: 'none'
+  };
+
   /**
    * Connection type
    * @return {string}


### PR DESCRIPTION
The network plugin offers a class with constants for the available connection types. This PR tries to recreate this with an enum.

Please let me know if there is a better way to do it.