### PR TITLE
docs(geolocation): use more generic / professional message

### DIFF
--- a/src/@ionic-native/plugins/geolocation/index.ts
+++ b/src/@ionic-native/plugins/geolocation/index.ts
@@ -114,7 +114,7 @@ export interface GeolocationOptions {
  * For iOS you have to add this configuration to your configuration.xml file
  * ```xml
  * <edit-config file="*-Info.plist" mode="merge" target="NSLocationWhenInUseUsageDescription">
- *    <string>We want your location! Best regards NSA</string>
+ *    <string>We use your location for full functionality of certain app features.</string>
  * </edit-config>
  * ```
  *


### PR DESCRIPTION
This is pretty nitpicky, but I think the existing documentation message is somewhat unprofessional. It's also very plausible that people will use this message in the docs as-is without thinking or realizing that it's intended to be changed (or reading it at all).

I propose a message that is hopefully generic enough to be used by any app if worse comes to worst while still communicating the same message.