### PR TITLE
docs(one-signal): fix target url for notification icon

### DIFF
--- a/src/@ionic-native/plugins/onesignal/index.ts
+++ b/src/@ionic-native/plugins/onesignal/index.ts
@@ -331,19 +331,19 @@ export enum OSActionType {
  *
  * var filestocopy = [{
  *     "resources/android/icon/drawable-hdpi-icon.png":
- *         "platforms/android/res/drawable-hdpi/ic_stat_onesignal_default.png"
+ *         "platforms/android/app/src/main/res/drawable-hdpi/ic_stat_onesignal_default.png"
  * }, {
  *     "resources/android/icon/drawable-mdpi-icon.png":
- *         "platforms/android/res/drawable-mdpi/ic_stat_onesignal_default.png"
+ *         "platforms/android/app/src/main/res/drawable-mdpi/ic_stat_onesignal_default.png"
  * }, {
  *     "resources/android/icon/drawable-xhdpi-icon.png":
- *         "platforms/android/res/drawable-xhdpi/ic_stat_onesignal_default.png"
+ *         "platforms/android/app/src/main/res/drawable-xhdpi/ic_stat_onesignal_default.png"
  * }, {
  *     "resources/android/icon/drawable-xxhdpi-icon.png":
- *         "platforms/android/res/drawable-xxhdpi/ic_stat_onesignal_default.png"
+ *         "platforms/android/app/src/main/res/drawable-xxhdpi/ic_stat_onesignal_default.png"
  * }, {
  *     "resources/android/icon/drawable-xxxhdpi-icon.png":
- *         "platforms/android/res/drawable-xxxhdpi/ic_stat_onesignal_default.png"
+ *         "platforms/android/app/src/main/res/drawable-xxxhdpi/ic_stat_onesignal_default.png"
  * } ];
  *
  * module.exports = function(context) {


### PR DESCRIPTION
The correct path is described at the official documentation from OneSignal. 
Link: https://documentation.onesignal.com/docs/customize-notification-icons