### PR TITLE
docs(Admob-Plus): fix the Plugin Name, added repo

### DIFF
--- a/src/@ionic-native/plugins/admob-plus/index.ts
+++ b/src/@ionic-native/plugins/admob-plus/index.ts
@@ -9,7 +9,7 @@ export type AdUnitIDOption = string | {
 };
 
 /**
- * @name AdMob Free
+ * @name AdMob Plus
  * @description
  * AdMob Plus is the successor of cordova-plugin-admob-free, which provides a cleaner API and build with modern tools.
  */
@@ -17,6 +17,8 @@ export type AdUnitIDOption = string | {
     plugin: 'cordova-admob-plus',
     pluginName: 'AdMob',
     pluginRef: 'admob.banner',
+    repo: 'https://github.com/admob-plus/admob-plus',
+    platforms: ['Android', 'iOS']
 })
 export class Banner {
     @Cordova({ otherPromise: true })


### PR DESCRIPTION
The newly added wrapper for Admob __Plus__  had Admob __Free__ as its name.

This resulted in a broken docs-Page:
An Entry named _Admob Free_ occurred twice, both showing infos for _Admob Plus_

see attached screenshot
![admob_plus](https://user-images.githubusercontent.com/7450884/47160469-55e73580-d2f0-11e8-87c9-bda4b5e664a1.png)
