### PR TITLE
feat(crashlytics): allow user to set userIdentifier for crashlytics

### DIFF
--- a/src/@ionic-native/plugins/firebase/index.ts
+++ b/src/@ionic-native/plugins/firebase/index.ts
@@ -308,6 +308,17 @@ export class Firebase extends IonicNativePlugin {
   }
 
   /**
+   * Allows the user to set User Identifier for crashlytics reporting
+   * https://firebase.google.com/docs/crashlytics/customize-crash-reports?authuser=0#set_user_ids
+   * @param {string} userId value to set the userId
+   * @returns {Promise<any>}
+   */
+  @Cordova()
+  setCrashlyticsUserId(userId: string): Promise<any> {
+    return;
+  }
+
+  /**
    * Sends an SMS to the user with the SMS verification code and returns the Verification ID required to sign in using phone authentication
    * @param {string} phoneNumber The phone number, including '+' and country code
    * @param {number} timeoutDuration (Android only) The timeout in sec - no more SMS will be sent to this number until this timeout expires


### PR DESCRIPTION
setting user identifier is available since [cordova-plugin-firebase@2.0.3](https://github.com/arnesson/cordova-plugin-firebase/blob/master/CHANGELOG.md#features)
added the functionality to the firebase ionic native plugin