### PR TITLE
fix(contacts plugin): add the rawId parameter

### DIFF
--- a/src/@ionic-native/plugins/contacts/index.ts
+++ b/src/@ionic-native/plugins/contacts/index.ts
@@ -44,7 +44,7 @@ export type ContactFieldType =
 export interface IContactProperties {
   /** A globally unique identifier. */
   id?: string;
-  
+
   /** A globally unique identifier on Android. */
   rawId?: string;
 

--- a/src/@ionic-native/plugins/contacts/index.ts
+++ b/src/@ionic-native/plugins/contacts/index.ts
@@ -44,6 +44,9 @@ export type ContactFieldType =
 export interface IContactProperties {
   /** A globally unique identifier. */
   id?: string;
+  
+  /** A globally unique identifier on Android. */
+  rawId?: string;
 
   /** The name of this Contact, suitable for display to end users. */
   displayName?: string;
@@ -91,6 +94,7 @@ export interface IContactProperties {
 export class Contact implements IContactProperties {
   private _objectInstance: any;
   @InstanceProperty id: string;
+  @InstanceProperty rawId: string;
   @InstanceProperty displayName: string;
   @InstanceProperty name: IContactName;
   @InstanceProperty nickname: string;


### PR DESCRIPTION
This adds the rawId parameter to the contact class which allows the rawId value to be passed to Android which is required for saving contacts.
This fixes issue #2760 
