### PR TITLE
refactor(keyboard-setResizeMode): use explicit type

### DIFF
--- a/src/@ionic-native/plugins/keyboard/index.ts
+++ b/src/@ionic-native/plugins/keyboard/index.ts
@@ -73,7 +73,7 @@ export class Keyboard extends IonicNativePlugin {
     sync: true,
     platforms: ['iOS']
   })
-  setResizeMode(mode: string): void {}
+  setResizeMode(mode: 'native' | 'body' | 'ionic'): void {}
 
   /**
    * Creates an observable that notifies you when the keyboard is shown. Unsubscribe to observable to cancel event watch.


### PR DESCRIPTION
This will ensure consumers of this plugin don't need to go on a quest of finding what the possible values are, the values are derived from [here](https://github.com/ionic-team/cordova-plugin-ionic-keyboard#keyboardresizemode)