### PR TITLE
refactor(card-io): allow number as type for guideColor

### DIFF
--- a/src/@ionic-native/plugins/card-io/index.ts
+++ b/src/@ionic-native/plugins/card-io/index.ts
@@ -60,7 +60,7 @@ export interface CardIOOptions {
   /**
    * Changes the color of the guide overlay on the camera. The color is provided in hexadecimal format (e.g. `#FFFFFF`)
    */
-  guideColor?: string|number;
+  guideColor?: string | number;
 
   /**
    * The user will not be prompted to confirm their card number after processing.

--- a/src/@ionic-native/plugins/card-io/index.ts
+++ b/src/@ionic-native/plugins/card-io/index.ts
@@ -60,7 +60,7 @@ export interface CardIOOptions {
   /**
    * Changes the color of the guide overlay on the camera. The color is provided in hexadecimal format (e.g. `#FFFFFF`)
    */
-  guideColor?: string;
+  guideColor?: string|number;
 
   /**
    * The user will not be prompted to confirm their card number after processing.


### PR DESCRIPTION
When the platform is Android, the cordova plugin wait for an Int value to set the guide color.