### PR TITLE
docs(camera): improve docs

### DIFF
--- a/src/@ionic-native/plugins/camera/index.ts
+++ b/src/@ionic-native/plugins/camera/index.ts
@@ -128,6 +128,8 @@ export enum Direction {
  *
  * Requires the Cordova plugin: `cordova-plugin-camera`. For more info, please see the [Cordova Camera Plugin Docs](https://github.com/apache/cordova-plugin-camera).
  *
+ * [Warning] Since IOS 10 the camera requires permissions to be placed in your config.xml add '<config-file parent="NSCameraUsageDescription" platform="ios" target="*-Info.plist"><string>You can take photos</string></config-file> inside of the <platform name='ios> section
+ *
  * @usage
  * ```typescript
  * import { Camera, CameraOptions } from '@ionic-native/camera';


### PR DESCRIPTION
Add permissions for IOS, as it shows camera in device showing black and no error is thrown