### PR TITLE
fix(health): fix typos

### DIFF
--- a/src/@ionic-native/plugins/health/index.ts
+++ b/src/@ionic-native/plugins/health/index.ts
@@ -266,7 +266,7 @@ export class Health extends IonicNativePlugin {
    *
    * Quirks of isAuthorized()
    *
-   * In iOS, this function will only check authorization status for writeable data.
+   * In iOS, this function will only check authorization status for writable data.
    * Read-only data will always be considered as not authorized. This is an intended behaviour of HealthKit.
    *
    * @param {Array<string | HealthDataType>} datatypes a list of data types you want to check access of, same as in requestAuthorization

--- a/src/@ionic-native/plugins/nfc/index.ts
+++ b/src/@ionic-native/plugins/nfc/index.ts
@@ -22,7 +22,7 @@ export interface NdefRecord {
 export interface NdefTag {
   canMakeReadOnly: boolean;
   id: number[];
-  isWriteable: boolean;
+  isWritable: boolean;
   maxSize: number;
   ndefMessage: NdefRecord[];
   techTypes: string[];
@@ -196,7 +196,7 @@ export class NFC extends IonicNativePlugin {
    * @returns {Promise<any>}
    */
   @Cordova()
-  makeReadyOnly(): Promise<any> {
+  makeReadOnly(): Promise<any> {
     return;
   }
 


### PR DESCRIPTION
ionic-native/nfc makeReadyOnly function and isWriteable has probably not been used much as they are pointing to not existing function and attribute.
makeReadyOnly should be makeReadOnly and isWriteable should be isWritable to match phonegap-nfc package method and attribute.
This Pull request fix this two typos.
This fix issue #2823