### PR TITLE
chore(template): reorder imports

### DIFF
--- a/scripts/templates/wrap-min.tmpl
+++ b/scripts/templates/wrap-min.tmpl
@@ -10,7 +10,7 @@
  *
  */
 import { Injectable } from '@angular/core';
-import { Plugin, Cordova, CordovaProperty, CordovaInstance, InstanceProperty, IonicNativePlugin } from '@ionic-native/core';
+import { Cordova, CordovaInstance, CordovaProperty, InstanceProperty, IonicNativePlugin, Plugin } from '@ionic-native/core';
 import { Observable } from 'rxjs/Observable';
 
 /**

--- a/scripts/templates/wrap.tmpl
+++ b/scripts/templates/wrap.tmpl
@@ -10,7 +10,7 @@
  *
  */
 import { Injectable } from '@angular/core';
-import { Plugin, Cordova, CordovaProperty, CordovaInstance, InstanceProperty, IonicNativePlugin } from '@ionic-native/core';
+import { Cordova, CordovaInstance, CordovaProperty, InstanceProperty, IonicNativePlugin, Plugin } from '@ionic-native/core';
 import { Observable } from 'rxjs/Observable';
 
 /**


### PR DESCRIPTION
I tried creating a new plugin, and building it. Then an error message was displayed.
```
Failed to lint: /path/to/ionic-native/src/@ionic-native/plugins/example/index.ts [13, 10]: Named imports must be alphabetized..
```

I found ordered-imports in tslint-ionic-rules. So I changed order.

https://github.com/ionic-team/tslint-ionic-rules/commit/54d3cf883ace941ca1962d96cdeadcb20203aee4