### PR TITLE
feat(in-app-browser): add 'beforeload' as option

### DIFF
--- a/src/@ionic-native/plugins/in-app-browser/index.ts
+++ b/src/@ionic-native/plugins/in-app-browser/index.ts
@@ -78,6 +78,8 @@ export interface InAppBrowserOptions {
   fullscreen?: 'yes';
   /** (Android Only) Sets whether the WebView should enable support for the "viewport" HTML meta tag or should use a wide viewport. When the value of the setting is no, the layout width is always set to the width of the WebView control in device-independent (CSS) pixels. When the value is yes and the page contains the viewport meta tag, the value of the width specified in the tag is used. If the page does not contain the tag or does not provide a width, then a wide viewport will be used. (defaults to yes). */
   useWideViewPort?: 'yes' | 'no';
+  /** Allows for latest 'beforeload' feature of Cordova InAppBrowser to be registered as an option if using plugin's latest github master (1/4/2019) instead of npm. Post is currently not supported but will be. */
+  beforeload?: 'yes' | 'post' | 'get';
   /**
    * @hidden
    */


### PR DESCRIPTION
Please see the issue I created here for more information: https://github.com/ionic-team/ionic-native/issues/2861

This allows Ionic-Native to be used with the latest features of Cordova InAppBrowser's github.

closes: #2861