### PR TITLE
fix(bluetooth-le): Fix typo in interface definition

### DIFF
--- a/src/@ionic-native/plugins/bluetooth-le/index.ts
+++ b/src/@ionic-native/plugins/bluetooth-le/index.ts
@@ -339,7 +339,7 @@ export interface InitializeResult {
   /** Service's UUID */
   service: string;
   /** Characteristic UUID */
-  characterisitc: string;
+  characteristic: string;
   /** This integer value will be incremented every read/writeRequested */
   requestId: number;
   /** Offset value */


### PR DESCRIPTION
Will this change eventually get to the v5 branch or would I need to do a separate PR to get it there?