### PR TITLE
fix(bluetooth-le): Fix typo in InitializeResult interface definition

### DIFF
--- a/src/@ionic-native/plugins/bluetooth-le/index.ts
+++ b/src/@ionic-native/plugins/bluetooth-le/index.ts
@@ -339,7 +339,7 @@ export interface InitializeResult {
   /** Service's UUID */
   service: string;
   /** Characteristic UUID */
-  characterisitc: string;
+  characteristic: string;
   /** This integer value will be incremented every read/writeRequested */
   requestId: number;
   /** Offset value */


### PR DESCRIPTION
It seems like my previous PR was overwritten on master.  Here it is again.  Fix #2890