### PR TITLE
feat(photo-viewer): add new params

### DIFF
--- a/src/@ionic-native/plugins/photo-viewer/index.ts
+++ b/src/@ionic-native/plugins/photo-viewer/index.ts
@@ -11,6 +11,22 @@ export interface PhotoViewerOptions {
    * The value is a string in a JSON format.  Default: ''
    */
   headers?: string;
+  /**
+   * Option for close button visibility when share false [ONLY FOR iOS]
+   */
+  closeButton?: boolean;
+  /**
+   * If you need to copy image to reference before show then set it true [ONLY FOR iOS]
+   */
+  copyToReference?: boolean;
+  /**
+   * Enable or Disable Picasso Options ( Only Android ): fit, centerInside, centerCrop.
+   */
+  piccasoOptions?: {
+    fit?: boolean;
+    centerInside?: boolean;
+    centerCrop?: boolean;
+  };
 }
 
 /**

--- a/src/@ionic-native/plugins/photo-viewer/index.ts
+++ b/src/@ionic-native/plugins/photo-viewer/index.ts
@@ -28,7 +28,7 @@ export interface PhotoViewerOptions {
  *
  * this.photoViewer.show('https://mysite.com/path/to/image.jpg', 'My image title', {share: false});
  *
- * this.photoViewer.show('https://mysecuresite.com/path/to/image.jpg', 'My image title', {share: false, headers: '{headers:{username:foo,password:bar}}'});
+ * this.photoViewer.show('https://mysecuresite.com/path/to/image.jpg', 'My image title', {share: false, headers: '{username:foo,password:bar}'});
  * ```
  */
 @Plugin({

--- a/src/@ionic-native/plugins/photo-viewer/index.ts
+++ b/src/@ionic-native/plugins/photo-viewer/index.ts
@@ -6,6 +6,11 @@ export interface PhotoViewerOptions {
    * Set to false to disable the share button (Android only). Default: true
    */
   share?: boolean;
+  /**
+   * Add HTTP headers to the request.  Useful for authenticated pages.
+   * The value is a string in a JSON format.  Default: ''
+   */
+  headers?: string;
 }
 
 /**
@@ -22,6 +27,8 @@ export interface PhotoViewerOptions {
  * this.photoViewer.show('https://mysite.com/path/to/image.jpg');
  *
  * this.photoViewer.show('https://mysite.com/path/to/image.jpg', 'My image title', {share: false});
+ *
+ * this.photoViewer.show('https://mysecuresite.com/path/to/image.jpg', 'My image title', {share: false, headers: '{headers:{username:foo,password:bar}}'});
  * ```
  */
 @Plugin({


### PR DESCRIPTION
As of 1.1.19 of PhotoViewer, a new PhotoViewer option was added called 'headers' which allows for HTTP headers to be used when requesting the image.  This is useful for authenticated sites.