### PR TITLE
fix(build): fixed duplicate import identifiers

### DIFF
--- a/scripts/build/transformers/imports.ts
+++ b/scripts/build/transformers/imports.ts
@@ -37,10 +37,15 @@ function transformImports(file: ts.SourceFile, ctx: ts.TransformationContext, ng
 
     decorators.forEach(d => methods = getMethodsForDecorator(d).concat(methods));
 
+    const methodElements = methods.map(m => ts.createIdentifier(m));
+    const methodNames = methodElements.map((el) => el.escapedText);
+
     importStatement.importClause.namedBindings.elements = [
       ts.createIdentifier('IonicNativePlugin'),
-      ...methods.map(m => ts.createIdentifier(m)),
-      ...importStatement.importClause.namedBindings.elements.filter(el => keep.indexOf(el.name.text) !== -1)
+      ...methodElements,
+      ...importStatement.importClause.namedBindings.elements.filter(
+        el => keep.indexOf(el.name.text) !== -1 && methodNames.indexOf(el.name.text) === -1
+      )
     ];
 
     if (ngcBuild) {


### PR DESCRIPTION
Fixes #2801 by preventing duplicate import identifiers when building `dist` which causes prod Ionic app builds to fail.

Duplicate imports prior to this fix were caused by importing `checkAvailability` and using `@CordovaCheck` in the same ts file as shown in `ionic-native/src/@ionic-native/plugins/contacts/index.ts`. 

Currently, only `contacts` is affected but the fix should mitigate any future occurrence. Here's the diff between before and after the fix using Beyond Compare:
![image](https://user-images.githubusercontent.com/3767490/52159785-44dfeb80-2677-11e9-9366-90e48faee41b.png)

![image](https://user-images.githubusercontent.com/3767490/52159802-68a33180-2677-11e9-8ea5-794416417c82.png)

Let me know if you need any more info! 😀

