### PR TITLE
fix(google-play-games-services): correct Cordova plugin name typo

### DIFF
--- a/src/@ionic-native/plugins/google-play-games-services/index.ts
+++ b/src/@ionic-native/plugins/google-play-games-services/index.ts
@@ -154,7 +154,7 @@ export interface Player {
  */
 @Plugin({
   pluginName: 'GooglePlayGamesServices',
-  plugin: 'cordova-plugin-play-games-service',
+  plugin: 'cordova-plugin-play-games-services',
   pluginRef: 'plugins.playGamesServices',
   repo: 'https://github.com/artberri/cordova-plugin-play-games-services',
   platforms: ['Android'],


### PR DESCRIPTION
closes ionic-team/ionic-docs#424