### PR TITLE
fix(in-app-purchase2): Registering a product with an alias is now optional

### DIFF
--- a/src/@ionic-native/plugins/in-app-purchase-2/index.ts
+++ b/src/@ionic-native/plugins/in-app-purchase-2/index.ts
@@ -73,7 +73,7 @@ import { Injectable } from '@angular/core';
 
 export interface IAPProductOptions {
   id: string;
-  alias: string;
+  alias?: string;
   type: string;
 }
 


### PR DESCRIPTION
According to the documentation, alias is optional
https://github.com/j3k0/cordova-plugin-purchase/blob/master/doc/api.md#storeregisterproduct

Short Description of the issue:
It is currently not possible to register a product without an alias using the ionic-native npm package for  [cordova-plugin-purchase](https://github.com/j3k0/cordova-plugin-purchase).

Steps to reproduce:
Try registering a product without an alias throws the following error:
`error TS2345: Argument of type '{ id: any; type: string; }' is not assignable to parameter of type 'IAPProductOptions'.
[ng]   Property 'alias' is missing in type '{ id: any; type: string; }'.`
