### PR TITLE
feat(in-app-purchase-2): add missing property

### DIFF
--- a/src/@ionic-native/plugins/in-app-purchase-2/index.ts
+++ b/src/@ionic-native/plugins/in-app-purchase-2/index.ts
@@ -228,6 +228,13 @@ export class InAppPurchase2 extends IonicNativePlugin {
   verbosity: number;
 
   /**
+   * Set to true to clear the transaction queue. Not recommended for production.
+   * https://github.com/j3k0/cordova-plugin-purchase/blob/master/doc/api.md#random-tips
+   */
+  @CordovaProperty()
+  autoFinishTransactions: boolean;
+
+  /**
    * Set to true to invoke the platform purchase sandbox. (Windows only)
    */
   @CordovaProperty()


### PR DESCRIPTION
Adding Cordova Property to account for the autoFinishTransactions property within cordova-plugin-purchase according to documentation at https://github.com/j3k0/cordova-plugin-purchase/blob/master/doc/api.md#random-tips