### PR TITLE
fix(build): check for TypeDoc tags when selecting plugin class

### DIFF
--- a/scripts/docs-json/index.ts
+++ b/scripts/docs-json/index.ts
@@ -90,7 +90,7 @@ const isClass = (child: any): boolean =>
   child.kind === 128;
 
 const isPlugin = (child: any): boolean =>
-  isClass(child) && Array.isArray(child.decorators) && child.decorators.some(d => d.name === 'Plugin');
+  isClass(child) && hasTags(child) && Array.isArray(child.decorators) && child.decorators.some(d => d.name === 'Plugin');
 
 const hasPlugin = (child: any): boolean =>
   child.children.some(isPlugin);


### PR DESCRIPTION
The `docs-json` script was, in one case, selecting the wrong class to document from a plugin module. This adds a check for TypeDoc comment tags to ensure we get the correct class.

```diff
- const isPlugin = (child: any): boolean => isClass(child) && Array.isArray(child.decorators) && child.decorators.some(d => d.name === 'Plugin');
+ const isPlugin = (child: any): boolean => isClass(child) && hasTags(child) && Array.isArray(child.decorators) && child.decorators.some(d => d.name === 'Plugin');
```