### PR TITLE
fix(google-plus): mark login param as required

### DIFF
--- a/src/@ionic-native/plugins/google-plus/index.ts
+++ b/src/@ionic-native/plugins/google-plus/index.ts
@@ -39,7 +39,7 @@ export class GooglePlus extends IonicNativePlugin {
     successIndex: 1,
     errorIndex: 2
   })
-  login(options?: any): Promise<any> {
+  login(options: any): Promise<any> {
     return;
   }
 


### PR DESCRIPTION
fixed if login's options is undefined, ios simulator will be throw the following error in runtime.
```
*** Terminating app due to uncaught exception 'NSInvalidArgumentException', reason: '-[NSNull objectForKeyedSubscript:]: unrecognized selector sent to instance 0x11255cea8'
```