### PR TITLE
feat(FileOpener): Added method showOpenWithDialog

### DIFF
--- a/src/@ionic-native/plugins/file-opener/index.ts
+++ b/src/@ionic-native/plugins/file-opener/index.ts
@@ -18,6 +18,10 @@ import { Cordova, IonicNativePlugin, Plugin } from '@ionic-native/core';
  *   .then(() => console.log('File is opened'))
  *   .catch(e => console.log('Error opening file', e));
  *
+ * this.fileOpener.showOpenWithDialog('path/to/file.pdf', 'application/pdf')
+ *   .then(() => console.log('File is opened'))
+ *   .catch(e => console.log('Error opening file', e));
+ *
  * ```
  */
 @Plugin({
@@ -69,6 +73,21 @@ export class FileOpener extends IonicNativePlugin {
     errorName: 'error'
   })
   appIsInstalled(packageId: string): Promise<any> {
+    return;
+  }
+
+  /**
+   * Opens with system modal to open file with an already installed app.
+   * @param {string} filePath File Path
+   * @param {string} fileMIMEType File MIME Type
+   * @returns {Promise<any>}
+   */
+  @Cordova({
+    callbackStyle: 'object',
+    successName: 'success',
+    errorName: 'error'
+  })
+  showOpenWithDialog(filePath: string, fileMIMEType: string): Promise<any> {
     return;
   }
 }


### PR DESCRIPTION
Added missing method 'showOpenWithDialog' from the underlaying plugin.
https://github.com/pwlin/cordova-plugin-file-opener2#fileopener2showopenwithdialogfilepath-mimetype-options

Needed if you want to open a file in other app without the need to preview it first.

- Tested it locally.
- Passed lint test.