### PR TITLE
feat(full-screen-image): add plugin

### DIFF
--- a/src/@ionic-native/plugins/full-screen-image/index.ts
+++ b/src/@ionic-native/plugins/full-screen-image/index.ts
@@ -1,0 +1,72 @@
+/**
+ * This is a template for new plugin wrappers
+ *
+ * TODO:
+ * - Add/Change information below
+ * - Document usage (importing, executing main functionality)
+ * - Remove any imports that you are not using
+ * - Remove all the comments included in this template, EXCEPT the @Plugin wrapper docs and any other docs you added
+ * - Remove this note
+ *
+ */
+import { Injectable } from '@angular/core';
+import { Plugin, Cordova, IonicNativePlugin } from '@ionic-native/core';
+
+/**
+ * @name Full Screen Image
+ * @description
+ * This plugin does something
+ *
+ * @usage
+ * ```typescript
+ * import { FullScreenImage } from '@ionic-native/full-screen-image';
+ *
+ *
+ * constructor(private fullScreenImage: FullScreenImage) { }
+ *
+ * ...
+ *
+ * this.fullScreenImage.showImageURL('/assets/...')
+ *   .then((data: any) => console.log(res))
+ *   .catch((error: any) => console.error(error));
+ *
+ * ...
+ *
+ * this.fullScreenImage.showImageBase64('iVBORw0KGgoAAAANSUhEUgAAA...')
+ *   .then((data: any) => console.log(res))
+ *   .catch((error: any) => console.error(error));
+ *
+ * ```
+ */
+@Plugin({
+  pluginName: 'FullScreenImage',
+  plugin: 'es.keensoft.fullscreenimage',
+  pluginRef: 'FullScreenImage',
+  repo: 'https://github.com/keensoft/FullScreenImage-Cordova-Plugin',
+  platforms: ['Android', 'iOS']
+})
+@Injectable()
+export class FullScreenImage extends IonicNativePlugin {
+
+  /**
+   * Opens an image from a URL or path
+   * @param url {string} url or image path
+   * @return {Promise<any>}
+   */
+  @Cordova({ sync: true })
+  showImageURL(url: string): Promise<any> {
+    return;
+  }
+
+  /**
+   * Opens an image from a base64 string
+   * @param base64String {string} base64 string
+   * @param name? {string} image name
+   * @param type? {string} image extension
+   * @return {Promise<any>}
+   */
+  @Cordova({ sync: true })
+  showImageBase64(base64String: string, name?: string, type?: string): Promise<any> {
+    return;
+  }
+}

--- a/src/@ionic-native/plugins/full-screen-image/index.ts
+++ b/src/@ionic-native/plugins/full-screen-image/index.ts
@@ -1,14 +1,3 @@
-/**
- * This is a template for new plugin wrappers
- *
- * TODO:
- * - Add/Change information below
- * - Document usage (importing, executing main functionality)
- * - Remove any imports that you are not using
- * - Remove all the comments included in this template, EXCEPT the @Plugin wrapper docs and any other docs you added
- * - Remove this note
- *
- */
 import { Injectable } from '@angular/core';
 import { Plugin, Cordova, IonicNativePlugin } from '@ionic-native/core';
 


### PR DESCRIPTION
Used for a Cordova plugin. The plugin converts base64 string to full-screen image or opens an image from a path.
The plugin is in the ionic origin project itself.