### PR TITLE
docs(developer): remove stale observation about methods being static

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -88,8 +88,6 @@ It's just a stub. The `return` is only there to keep the TypeScript type-checker
 
 By default, the `@Cordova` decorator wraps the plugin callbacks in a Promise that resolves when the success callback is called and rejects when the error callback is called.  It also ensures that Cordova and the underlying plugin are available, and prints helpful diagnostics if they aren't.
 
-You'll also notice that `getCurrentPosition` is a static method. That's because the plugin class is just a utility class to call the underlying Cordova plugin methods, it's not an instance and has no state.
-
 Next, let's look at the `watchPosition` method.
 
 ```


### PR DESCRIPTION
This removes a comment about methods being static that I believe is a (now misleading) remnant of v2 days before ionic-native wrappers were refactored to become injectable objects.