### PR TITLE
Fixed syntax for closing a tag

### DIFF
--- a/src/@ionic-native/plugins/music-controls/index.ts
+++ b/src/@ionic-native/plugins/music-controls/index.ts
@@ -134,6 +134,7 @@ export interface MusicControlsOptions {
  *      			break;
  *      	}
  *      }
+ *     });
  *
  *  this.musicControls.listen(); // activates the observable above
  *


### PR DESCRIPTION
The function this.musicControls.subscribe().subscribe was not closed properly, I added the proper syntax for closing the tag.