### PR TITLE
feat(in-app-purchase-2): update TypeScript definitions

### DIFF
--- a/src/@ionic-native/plugins/in-app-purchase-2/index.ts
+++ b/src/@ionic-native/plugins/in-app-purchase-2/index.ts
@@ -4,7 +4,7 @@ import { Injectable } from '@angular/core';
 /**
  * @name In App Purchase 2
  * @description
- * In-App Purchase for Cordova on iOS, Android and Windows
+ * In-App Purchase for Cordova on iOS, Android, Windows, macOS and XBox.
  *
  * @usage
  * ```typescript
@@ -33,17 +33,17 @@ import { Injectable } from '@angular/core';
  *
  *    // Updated
  *    this.store.when(productId).updated( (product: IAPProduct) => {
- *      console.log('Loaded' + JSON.stringify(product));
+ *      console.log('Updated' + JSON.stringify(product));
  *    });
  *
  *    // Issue with buying
  *     this.store.when(productId).cancelled( (product) => {
- *         alert('Purchase was Cancelled');
+ *         console.error('Purchase was Cancelled');
  *     });
  *
  *      // Track All Store Errors
  *     this.store.error( (err) => {
- *       alert('Store Error ' + JSON.stringify(err));
+ *       console.error('Store Error ' + JSON.stringify(err));
  *     });
  *
  *     this.store.ready(() =>  {
@@ -56,7 +56,7 @@ import { Injectable } from '@angular/core';
  *     // Errors
  *     this.store.when(productId).error( (error) => {
  *       this.loader.dismiss();
- *       alert('An Error Occured' + JSON.stringify(error));
+ *       console.error('An Error Occured' + JSON.stringify(error));
  *     });
  *     // Refresh Starts Handlers
  *     console.log('Refresh Store');
@@ -125,6 +125,30 @@ export interface IAPProduct {
   downloading: boolean;
 
   downloaded: boolean;
+
+  lastRenewalDate: Date;
+
+  expiryDate: Date;
+
+  introPrice: string;
+
+  introPriceMicros: number;
+
+  introPriceNumberOfPeriods: number;
+
+  introPriceSubscriptionPeriod: string;
+
+  introPricePaymentMode: string;
+
+  ineligibleForIntroPrice: boolean;
+
+  billingPeriod: number;
+
+  billingPeriodUnit: string;
+
+  trialPeriod: number;
+
+  trialPeriodUnit: string;
 
   additionalData: any;
 


### PR DESCRIPTION
Hey, I'm the maintainer of `cordova-plugin-purchase`, the cordova plugin used by `in-app-purchase-2`. I made some changes requested by users to the TypeScript definition, but I'm not ionic developer, I'm new to TypeScript, and don't know how to test the changes ;-)

Looks simple and it should probably work, but it'd be better to actually try it!

On a different note: how to update the page https://ionicframework.com/docs/native/in-app-purchase-2 ? The plugin now supports macOS and Microsoft UWP, plus it'd be nice to show more documentation, I can probably help with that.