### PR TITLE
feat(diagnostic): add requestRemoteNotificationsAuthorization method

### DIFF
--- a/src/@ionic-native/plugins/diagnostic/index.ts
+++ b/src/@ionic-native/plugins/diagnostic/index.ts
@@ -813,6 +813,15 @@ export class Diagnostic extends IonicNativePlugin {
   }
 
   /**
+   * Requests reminders authorization for the application.
+   * @returns {Promise<any>}
+   */
+  @Cordova({ platforms: ['iOS'] })
+  requestRemoteNotificationsAuthorization(types?: string[], omitRegistration?: boolean): Promise<string> {
+    return;
+  }
+
+  /**
    * Indicates the current setting of notification types for the app in the Settings app.
    * Note: on iOS 8+, if "Allow Notifications" switch is OFF, all types will be returned as disabled.
    * @returns {Promise<any>}


### PR DESCRIPTION
solves #3050

while diagnostic plugin docs may be confusing, the `requestRemoteNotificationsAuthorization(successCallback, errorCallback, types, omitRegistration)` signature is available in the sources:

https://github.com/dpa99c/cordova-diagnostic-plugin/blob/0fac4a59d1f246c872c05f513b09f0e9c93abb51/www/ios/diagnostic.notifications.js#L162