### PR TITLE
fix(music-control): use correct input type

### DIFF
--- a/src/@ionic-native/plugins/music-controls/index.ts
+++ b/src/@ionic-native/plugins/music-controls/index.ts
@@ -204,7 +204,7 @@ export class MusicControls extends IonicNativePlugin {
   @Cordova({
     platforms: ['iOS']
   })
-  updateElapsed(args: { elapsed: string; isPlaying: boolean }): void {}
+  updateElapsed(args: { elapsed: number; isPlaying: boolean }): void {}
 
   /**
    * Toggle dismissable:


### PR DESCRIPTION
Changed `updateElapsed()` argument's `elapsed` from string to number.
If string value is passed to it, MusicControl fully stops working.