### PR TITLE
fix(firebase): add missing decorator to clearAllNotifications

### DIFF
--- a/src/@ionic-native/plugins/firebase/index.ts
+++ b/src/@ionic-native/plugins/firebase/index.ts
@@ -343,6 +343,9 @@ export class Firebase extends IonicNativePlugin {
    * Clear all pending notifications from the drawer
    * @return {Promise<any>}
    */
+  @Cordova({
+    platforms: ['Android']
+  })
   clearAllNotifications(): Promise<any> {
     return;
   }


### PR DESCRIPTION
Added a missing call to cordova to use the clearAllNotifications from cordova-plugin-firebase