### PR TITLE
fix(in-app-purchase-2): add missing option to register function

### DIFF
--- a/src/@ionic-native/plugins/in-app-purchase-2/index.ts
+++ b/src/@ionic-native/plugins/in-app-purchase-2/index.ts
@@ -761,7 +761,7 @@ export class InAppPurchase2 extends IonicNativePlugin {
    * @param product {IAPProductOptions}
    */
   @Cordova({ sync: true })
-  register(product: IAPProductOptions): void {}
+  register(product: IAPProductOptions || IAPProductOptions[]): void {}
 
   /**
    *

--- a/src/@ionic-native/plugins/in-app-purchase-2/index.ts
+++ b/src/@ionic-native/plugins/in-app-purchase-2/index.ts
@@ -761,7 +761,7 @@ export class InAppPurchase2 extends IonicNativePlugin {
    * @param product {IAPProductOptions}
    */
   @Cordova({ sync: true })
-  register(product: IAPProductOptions || IAPProductOptions[]): void {}
+  register(product: IAPProductOptions | IAPProductOptions[]): void {}
 
   /**
    *


### PR DESCRIPTION
It should accept also a list of IAPProductOptions