### PR TITLE
refactor(core): allow rxjs 5.5 as peer dependency

### DIFF
--- a/scripts/tasks/publish.ts
+++ b/scripts/tasks/publish.ts
@@ -30,7 +30,7 @@ const DIST = path.resolve(ROOT, 'dist/@ionic-native');
 const PACKAGES = [];
 
 const MIN_CORE_VERSION = '^5.1.0';
-const RXJS_VERSION = '^6.5.0';
+const RXJS_VERSION = '^5.5.0 || ^6.5.0';
 
 const PLUGIN_PEER_DEPENDENCIES = {
   '@ionic-native/core': MIN_CORE_VERSION,


### PR DESCRIPTION
This would allow Ionic v3 apps to use Ionic Native v5 wrappers.