### PR TITLE
chore(scripts): add installVariables to docs-json output

### DIFF
--- a/scripts/docs-json/index.ts
+++ b/scripts/docs-json/index.ts
@@ -10,6 +10,7 @@ interface Plugin {
   platforms: string[];
   usage: string;
   repo: string;
+  installVariables: string[];
   cordovaPlugin: {
     name: string;
   };
@@ -56,6 +57,7 @@ function processPlugin(pluginModule): Plugin {
     usage,
     platforms: decorator.platforms,
     repo: decorator.repo,
+    installVariables: decorator.installVariables,
     cordovaPlugin: {
       name: decorator.plugin
     }


### PR DESCRIPTION
In a few places where we use the output of the `docs-json` script, we need the `installVariables` from the plugin decorator. This adds it to the script output.