### PR TITLE
feat(theme-detection): add plugin

### DIFF
--- a/src/@ionic-native/plugins/theme-detection/index.ts
+++ b/src/@ionic-native/plugins/theme-detection/index.ts
@@ -1,0 +1,72 @@
+import { Injectable } from '@angular/core';
+import { Plugin, Cordova, IonicNativePlugin } from '@ionic-native/core';
+
+export interface ThemeDetectionResponse {
+  // Boolean value about the status of the request
+  value: boolean;
+
+  // Message for readable usage
+  message: string;
+}
+
+/**
+ * @beta
+ * @name Theme Detection
+ * @description
+ * Cordova plugin to detect whether dark mode is enabled or not
+ *
+ * @usage
+ * ```typescript
+ * import { ThemeDetection } from '@ionic-native/theme-detection';
+ *
+ *
+ * constructor(private themeDetection: ThemeDetection) { }
+ *
+ * ...
+ *
+ * this.themeDetection.isAvailable()
+ *   .then((res: ThemeDetectionResponse) => {
+ *      if(res.value) {
+ *        this.themeDetection.isDarkModeEnabled().then((res: ThemeDetectionResponse) => {
+ *          console.log(res);
+ *        })
+ *        .catch((error: any) => console.error(error));
+ *      }
+ *   })
+ *   .catch((error: any) => console.error(error));
+ *
+ * ```
+ */
+@Plugin({
+  pluginName: 'ThemeDetection',
+  plugin: 'cordova-plugin-theme-detection',
+  pluginRef: 'cordova.plugins.ThemeDetection',
+  repo: 'https://github.com/mariusbackes/cordova-plugin-theme-detection',
+  install: 'cordova plugin add cordova-plugin-theme-detection',
+  installVariables: [],
+  platforms: ['iOS']
+})
+@Injectable()
+export class ThemeDetection extends IonicNativePlugin {
+
+  /**
+   *
+   * @return {Promise<ThemeDetectionResponse>}
+   *  Returns a promise with an object that has a boolean property which gives information if the detection is available or not
+   */
+  @Cordova()
+  isAvailable(): Promise<ThemeDetectionResponse> {
+    return;
+  }
+
+  /**
+   *
+   * @return {Promise<ThemeDetectionResponse>}
+   *  Returns a promise with an object that has a boolean property which gives information if dark mode is enabled or not
+   */
+  @Cordova()
+  isDarkModeEnabled(): Promise<ThemeDetectionResponse> {
+    return;
+  }
+
+}


### PR DESCRIPTION
Ionic Native Wrapper to detect the active theme (light or dark) on iOS devices.

URL: https://github.com/mariusbackes/cordova-plugin-theme-detection