### PR TITLE
docs(image-picker): set docs repo url to active repo

### DIFF
--- a/src/@ionic-native/plugins/image-picker/index.ts
+++ b/src/@ionic-native/plugins/image-picker/index.ts
@@ -42,7 +42,7 @@ export enum OutputType {
  * Cordova Plugin For Multiple Image Selection
  *
  * Requires Cordova plugin: `cordova-plugin-image-picker`.
- * For more info, please see the https://github.com/wymsee/cordova-imagePicker
+ * For more info, please see the https://github.com/Telerik-Verified-Plugins/ImagePicker
  *
  * @usage
  * ```typescript


### PR DESCRIPTION
Original repo hasn't had a commit since 2016. 

`Repo:` parameter already updated, but intro docs wasn't.