### PR TITLE
fix(ms-adal): use correct accessTokenType prop

### DIFF
--- a/src/@ionic-native/plugins/ms-adal/index.ts
+++ b/src/@ionic-native/plugins/ms-adal/index.ts
@@ -3,7 +3,7 @@ import { CordovaInstance, InstanceProperty, IonicNativePlugin, Plugin, checkAvai
 
 export interface AuthenticationResult {
   accessToken: string;
-  accesSTokenType: string;
+  accessTokenType: string;
   expiresOn: Date;
   idToken: string;
   isMultipleResourceRefreshToken: boolean;


### PR DESCRIPTION
Removed a typo, which made the Access Token Type undefined all the time.