### PR TITLE
feat(cordova-plugin-preview-any-file): add new plugin to preview the …

### DIFF
--- a/src/@ionic-native/plugins/preview-any-file/index.ts
+++ b/src/@ionic-native/plugins/preview-any-file/index.ts
@@ -1,9 +1,9 @@
 import { Injectable } from '@angular/core';
 import { Plugin, Cordova, IonicNativePlugin } from '@ionic-native/core';
 /**
- * @name Preview Any File
+ * @name PreviewAnyFile
  * @description
- * This plugin does something
+ * Whatever the file is PDF document, Word document, Excel, office document,zip archive file, image, text, html or anything else, you can perform a preview by this cordova Plugin to preview any file in native mode by providing the local or external URL.
  *
  * @usage
  * ```typescript
@@ -33,12 +33,12 @@ import { Plugin, Cordova, IonicNativePlugin } from '@ionic-native/core';
 @Injectable()
 export class PreviewAnyFile extends IonicNativePlugin {
   /**
-   * This function does something
-   * @param url {string} full absolute URL for the file
-   * @return {Promise<any>} Returns a promise that resolves when something happens
+   * this function return SUCCESS in success callback if the file successfully opened, if the content is base64 you have to write it into file by cordova-plugin-file
+   * @param url {string} full absolute URL for the file, if the path is content:// you need to resolve the native url, if the path is https:// it may not work in android
+   * @return {Promise<any>} Returns a promise that resolves if the file opened reject if not;
    */
   @Cordova()
-  preview(url: string): Promise<any> {
-    return; // We add return; here to avoid any IDE / Compiler errors
+  preview(url: string): Promise<string> {
+    return;
   }
 }

--- a/src/@ionic-native/plugins/preview-any-file/index.ts
+++ b/src/@ionic-native/plugins/preview-any-file/index.ts
@@ -1,0 +1,47 @@
+import { Injectable } from '@angular/core';
+import { Plugin, Cordova, IonicNativePlugin } from '@ionic-native/core';
+
+/**
+ * @name Preview Any File
+ * @description
+ * This plugin does something
+ *
+ * @usage
+ * ```typescript
+ * import { PreviewAnyFile } from '@ionic-native/preview-any-file';
+ *
+ *
+ * constructor(private previewAnyFile: PreviewAnyFile) { }
+ *
+ * ...
+ *
+ *
+ * this.previewAnyFile.preview('file://filepath.ext')
+ *   .then((res: any) => console.log(res))
+ *   .catch((error: any) => console.error(error));
+ *
+ * ```
+ */
+@Plugin({
+  pluginName: 'PreviewAnyFile',
+  plugin: 'cordova-plugin-preview-any-file', // npm package name, example: cordova-plugin-camera
+  pluginRef: 'PreviewAnyFile', // the variable reference to call the plugin, example: navigator.geolocation
+  repo: 'https://github.com/mostafa-mansour1/previewAnyFile', // the github repository URL for the plugin
+  install: '', // OPTIONAL install command, in case the plugin requires variables
+  installVariables: [], // OPTIONAL the plugin requires variables
+  platforms: ['Android', 'iOS'] // Array of platforms supported, example: ['Android', 'iOS']
+})
+@Injectable()
+export class PreviewAnyFile extends IonicNativePlugin {
+
+  /**
+   * This function does something
+   * @param arg1 {string} full absolute URL for the file 
+   * @return {Promise<any>} Returns a promise that resolves when something happens
+   */
+  @Cordova()
+  preview(arg1: string): Promise<any> {
+    return; // We add return; here to avoid any IDE / Compiler errors
+  }
+
+}

--- a/src/@ionic-native/plugins/preview-any-file/index.ts
+++ b/src/@ionic-native/plugins/preview-any-file/index.ts
@@ -1,6 +1,5 @@
 import { Injectable } from '@angular/core';
 import { Plugin, Cordova, IonicNativePlugin } from '@ionic-native/core';
-
 /**
  * @name Preview Any File
  * @description
@@ -33,15 +32,13 @@ import { Plugin, Cordova, IonicNativePlugin } from '@ionic-native/core';
 })
 @Injectable()
 export class PreviewAnyFile extends IonicNativePlugin {
-
   /**
    * This function does something
-   * @param arg1 {string} full absolute URL for the file 
+   * @param url {string} full absolute URL for the file
    * @return {Promise<any>} Returns a promise that resolves when something happens
    */
   @Cordova()
-  preview(arg1: string): Promise<any> {
+  preview(url: string): Promise<any> {
     return; // We add return; here to avoid any IDE / Compiler errors
   }
-
 }

--- a/src/@ionic-native/plugins/preview-any-file/index.ts
+++ b/src/@ionic-native/plugins/preview-any-file/index.ts
@@ -5,6 +5,8 @@ import { Plugin, Cordova, IonicNativePlugin } from '@ionic-native/core';
  * @description
  * Whatever the file is PDF document, Word document, Excel, office document,zip archive file, image, text, html or anything else, you can perform a preview by this cordova Plugin to preview any file in native mode by providing the local or external URL.
  *
+ *  Requires Cordova plugin: `cordova-plugin-preview-any-file`. For more info, please see the [previewAnyFile plugin docs](https://github.com/mostafa-mansour1/previewAnyFile).
+ *
  * @usage
  * ```typescript
  * import { PreviewAnyFile } from '@ionic-native/preview-any-file';


### PR DESCRIPTION
this is a wrapper for my developed plugin cordova-plugin-preview-any-file

this plugin is to open a preview in both android and ios regardless the type of the file. it use the same behavior of the file explorer in the device .

to test run
```
ionic cordova plugin add cordova-plugin-preview-any-file
```
```
npm install @ionic-native/preview-any-file
```
