### PR TITLE
fix(app-rate) add missing locale properties

### DIFF
--- a/src/@ionic-native/plugins/app-rate/index.ts
+++ b/src/@ionic-native/plugins/app-rate/index.ts
@@ -80,6 +80,12 @@ export interface AppRateCustomLocale {
 
   /** Feedback prompt title */
   feedbackPromptTitle?: string;
+
+  /** Feedback prompt message */
+  appRatePromptMessage?: string;
+
+  /** Feedback prompt message */
+  feedbackPromptMessage?: string;
 }
 
 export interface AppRateCallbacks {


### PR DESCRIPTION
Add missing locale properties from the cordova plugin:
https://github.com/pushandplay/cordova-plugin-apprate/blob/master/typescript/AppRate.d.ts#L57