### PR TITLE
fix(core): Return the window object as default instead of the boolean from the typeof comparison

### DIFF
--- a/src/@ionic-native/core/decorators/common.ts
+++ b/src/@ionic-native/core/decorators/common.ts
@@ -149,7 +149,7 @@ function wrapObservable(pluginObj: any, methodName: string, args: any[], opts: a
  * @returns {Observable}
  */
 function wrapEventObservable(event: string, element: any): Observable<any> {
-  element = (typeof window !== 'undefined' && element) ? get(window, element) : element || window || {};
+  element = (typeof window !== 'undefined' && element) ? get(window, element) : element || (typeof window !== 'undefined' ? window : {});
   return fromEvent(element, event);
 }
 

--- a/src/@ionic-native/core/decorators/common.ts
+++ b/src/@ionic-native/core/decorators/common.ts
@@ -149,7 +149,7 @@ function wrapObservable(pluginObj: any, methodName: string, args: any[], opts: a
  * @returns {Observable}
  */
 function wrapEventObservable(event: string, element: any): Observable<any> {
-  element = (typeof window !== 'undefined' && element) ? get(window, element) : element || typeof window !== 'undefined' || {};
+  element = (typeof window !== 'undefined' && element) ? get(window, element) : element || window || {};
   return fromEvent(element, event);
 }
 


### PR DESCRIPTION
Return the window object as default instead of the boolean from the typeof comparison.
Otherwise the target event is invalid. Because it's a boolean, not an object. (like window).
Please see this issue for details. Fixes https://github.com/ionic-team/ionic-native/issues/2972 and all other related issues. This is a blocker bug. Please merge and release it as soon as possible. @danielsogl 