### PR TITLE
Fix typings for hasPermission()

### DIFF
--- a/src/@ionic-native/plugins/firebase-x/index.ts
+++ b/src/@ionic-native/plugins/firebase-x/index.ts
@@ -151,10 +151,10 @@ export class FirebaseX extends IonicNativePlugin {
 
   /**
    * Check permission to receive push notifications and return hasPermission: true. iOS only (Android will always return true).
-   * @return {Promise<{isEnabled: boolean}>}
+   * @return {Promise<boolean>}
    */
   @Cordova()
-  hasPermission(): Promise<{ isEnabled: boolean }> {
+  hasPermission(): Promise<boolean> {
     return;
   }
 


### PR DESCRIPTION
Current version of plugin has change, described in https://github.com/dpa99c/cordova-plugin-firebasex#breaking-api-changes, this commit fixed `hasPermission()` method typings