### PR TITLE
feat(sign-in-with-apple): add plugin

### DIFF
--- a/src/@ionic-native/plugins/sign-in-with-apple/index.ts
+++ b/src/@ionic-native/plugins/sign-in-with-apple/index.ts
@@ -2,6 +2,27 @@ import { Injectable } from '@angular/core';
 import { Plugin, Cordova, CordovaProperty, CordovaInstance, InstanceProperty, IonicNativePlugin } from '@ionic-native/core';
 import { Observable } from 'rxjs';
 
+/**
+ * @name SignInWithApple
+ * @description
+ * This plugin provides Sign in With Apple native feature
+ *
+ * @usage
+ * ```typescript
+ * import { SignInWithApple } from '@ionic-native/sign-in-with-apple';
+ *
+ *
+ * constructor(private signInWithApple: SignInWithApple) { }
+ *
+ * ...
+ *
+ *
+ * this.signInWithApple.signin({})
+ *   .then((res: any) => console.log(res)) // contains token, user's name, email, etc.
+ *   .catch((error: any) => console.error(error));
+ *
+ * ```
+ */
 @Plugin({
   pluginName: 'SignInWithApple',
   repo: 'https://github.com/twogate/cordova-plugin-sign-in-with-apple/blob/master/plugin.xml',
@@ -11,6 +32,11 @@ import { Observable } from 'rxjs';
 })
 @Injectable()
 export class SignInWithApple extends IonicNativePlugin {
+  /**
+   * Show iOS's Sign in with Apple screen
+   * @param opts {any} Sign in with Apple options
+   * @return {Promise<any>} Returns a promise that resolves when complete Sign in with Apple
+   */
   @Cordova()
   signin(opts?: any): Promise<any> {
     return;

--- a/src/@ionic-native/plugins/sign-in-with-apple/index.ts
+++ b/src/@ionic-native/plugins/sign-in-with-apple/index.ts
@@ -1,6 +1,5 @@
 import { Injectable } from '@angular/core';
-import { Plugin, Cordova, CordovaProperty, CordovaInstance, InstanceProperty, IonicNativePlugin } from '@ionic-native/core';
-import { Observable } from 'rxjs';
+import { Plugin, Cordova, IonicNativePlugin } from '@ionic-native/core';
 
 /**
  * @name SignInWithApple

--- a/src/@ionic-native/plugins/sign-in-with-apple/index.ts
+++ b/src/@ionic-native/plugins/sign-in-with-apple/index.ts
@@ -1,0 +1,18 @@
+import { Injectable } from '@angular/core';
+import { Plugin, Cordova, CordovaProperty, CordovaInstance, InstanceProperty, IonicNativePlugin } from '@ionic-native/core';
+import { Observable } from 'rxjs';
+
+@Plugin({
+  pluginName: 'SignInWithApple',
+  repo: 'https://github.com/twogate/cordova-plugin-sign-in-with-apple/blob/master/plugin.xml',
+  plugin: 'cordova-plugin-sign-in-with-apple',
+  pluginRef: 'cordova.plugins.SignInWithApple',
+  platforms: ['iOS'],
+})
+@Injectable()
+export class SignInWithApple extends IonicNativePlugin {
+  @Cordova()
+  signin(opts?: any): Promise<any> {
+    return;
+  }
+}


### PR DESCRIPTION
this is an ionic-native wrapper for '[cordova-plugin-sign-in-with-apple](https://github.com/twogate/cordova-plugin-sign-in-with-apple)' that is for apple's new authentication architecture 'Sign in with Apple'.

to use the plugin:
```bash
ionic cordova plugin add  https://github.com/twogate/cordova-plugin-sign-in-w
ith-apple.git
```

you should need XCode >= 11.0 beta 6 and iOS (Simulator) >= 13 to run this plugin.

blocks: https://github.com/ionic-team/ionic-native/pull/3165