### PR TITLE
feat(document-scanner): add quality and base64

### DIFF
--- a/src/@ionic-native/plugins/document-scanner/index.ts
+++ b/src/@ionic-native/plugins/document-scanner/index.ts
@@ -38,7 +38,7 @@ export interface DocumentScannerOptions {
 
   /**
    * If the image should be returned as a base64 encoding instead of as a file URL.
-   * If true, the plugin will return the scanned image as base64. If false, 
+   * If true, the plugin will return the scanned image as base64. If false,
    * the plugin will return the image URL of the image.
    */
   returnBase64?: boolean;

--- a/src/@ionic-native/plugins/document-scanner/index.ts
+++ b/src/@ionic-native/plugins/document-scanner/index.ts
@@ -27,6 +27,21 @@ export interface DocumentScannerOptions {
    * which is "image".
    */
   fileName?: string;
+
+  /**
+   * Quality to use when capturing the image, must be a float value
+   * from 1.0(default - Highest quality) to 5.0(Lowest Quality). Any value
+   * in between will be accepted. Any value not equal to or not between these values
+   *  will default to the highest quality of 1.0.
+   */
+  quality?: number;
+
+  /**
+   * If the image should be returned as a base64 encoding instead of as a file URL.
+   * If true, the plugin will return the scanned image as base64. If false, 
+   * the plugin will return the image URL of the image.
+   */
+  returnBase64?: boolean;
 }
 
 /**


### PR DESCRIPTION
Add missing quality and returnBase64 properties from the cordova plugin:
[cordova-plugin-document-scanner](https://github.com/NeutrinosPlatform/cordova-plugin-document-scanner/blob/ade91c2f335d5be8ea42a84fadd8759cf5370db6/www/scan.js#L7)