### PR TITLE
fix(file): method writeExistingFile should return same type as writeFile

### DIFF
--- a/src/@ionic-native/plugins/file/index.ts
+++ b/src/@ionic-native/plugins/file/index.ts
@@ -1155,14 +1155,14 @@ export class File extends IonicNativePlugin {
    * @param {string} path Base FileSystem. Please refer to the iOS and Android filesystem above
    * @param {string} fileName path relative to base path
    * @param {string | Blob} text content or blob to write
-   * @returns {Promise<void>} Returns a Promise that resolves or rejects with an error.
+   * @returns {Promise<any>} Returns a Promise that resolves to updated file entry or rejects with an error.
    */
   @CordovaCheck()
   writeExistingFile(
     path: string,
     fileName: string,
     text: string | Blob
-  ): Promise<void> {
+  ): Promise<any> {
     return this.writeFile(path, fileName, text, { replace: true });
   }
 


### PR DESCRIPTION
As the `writeExistingFile` method use `writeFile` method is should return the same type.