### PR TITLE
feat(web-socket-server): Add cordova plugin websocket server

### DIFF
--- a/src/@ionic-native/plugins/web-socket-server/index.ts
+++ b/src/@ionic-native/plugins/web-socket-server/index.ts
@@ -4,9 +4,9 @@ import { Observable } from 'rxjs';
 
 declare const window: any;
 
-export type WebSocketInterfaces = {
+export interface WebSocketInterfaces {
   [key: string]: WebSocketInterface;
-};
+}
 
 export interface WebSocketInterface {
   ipv4Addresses: string[];
@@ -84,15 +84,15 @@ export interface HttpFields {
  *   next: server => console.log(`Listening on ${server.addr}:${server.port}`),
  *   error: error => console.log(`Unexpected error`, error);
  * });
- * 
+ *
  * // watch for any messages
  * this.wsserver.watchMessage().subscribe(result => {
  *   console.log(`Received message ${result.msg} from ${result.conn.uuid}`);
  * });
- * 
+ *
  * // send message to connection with specified uuid
  * this.wsserver.send({ uuid: '8e7c4f48-de68-4b6f-8fca-1067a353968d' }, 'Hello World');
- * 
+ *
  * // stop websocket server
  * this.wsserver.stop().then(server => {
  *   console.log(`Stop listening on ${server.addr}:${server.port}`);

--- a/src/@ionic-native/plugins/web-socket-server/index.ts
+++ b/src/@ionic-native/plugins/web-socket-server/index.ts
@@ -1,6 +1,6 @@
-import { Injectable } from "@angular/core";
-import { Plugin, Cordova, IonicNativePlugin } from "@ionic-native/core";
-import { Observable } from "rxjs";
+import { Injectable } from '@angular/core';
+import { Plugin, Cordova, IonicNativePlugin } from '@ionic-native/core';
+import { Observable } from 'rxjs';
 
 declare const window: any;
 
@@ -46,24 +46,24 @@ export interface WebSocketClose {
 
 export interface WebSocketConnection extends WebSocketIdentifier {
   remoteAttr: string;
-  state: "open" | "closed";
+  state: 'open' | 'closed';
   httpFields: HttpFields;
   resource: string;
 }
 
 export interface HttpFields {
-  "Accept-Encoding": string;
-  "Accept-Language": string;
-  "Cache-Control": string;
+  'Accept-Encoding': string;
+  'Accept-Language': string;
+  'Cache-Control': string;
   Connection: string;
   Host: string;
   Origin: string;
   Pragma: string;
-  "Sec-WebSocket-Extensions": string;
-  "Sec-WebSocket-Key": string;
-  "Sec-WebSocket-Version": string;
+  'Sec-WebSocket-Extensions': string;
+  'Sec-WebSocket-Key': string;
+  'Sec-WebSocket-Version': string;
   Upgrade: string;
-  "User-Agent": string;
+  'User-Agent': string;
 }
 
 /**
@@ -101,11 +101,11 @@ export interface HttpFields {
  * ```
  */
 @Plugin({
-  pluginName: "WebSocketServer",
-  plugin: "cordova-plugin-websocket-server",
-  pluginRef: "cordova.plugins.wsserver",
-  repo: "https://github.com/becvert/cordova-plugin-websocket-server",
-  platforms: ["Android", "iOS"]
+  pluginName: 'WebSocketServer',
+  plugin: 'cordova-plugin-websocket-server',
+  pluginRef: 'cordova.plugins.wsserver',
+  repo: 'https://github.com/becvert/cordova-plugin-websocket-server',
+  platforms: ['Android', 'iOS']
 })
 @Injectable()
 export class WebSocketServer extends IonicNativePlugin {
@@ -127,7 +127,7 @@ export class WebSocketServer extends IonicNativePlugin {
    */
   @Cordova({
     observable: true,
-    clearFunction: "stop"
+    clearFunction: 'stop'
   })
   start(port: number, options: WebSocketOptions): Observable<WebSocketServerDetails> {
     return;
@@ -149,7 +149,7 @@ export class WebSocketServer extends IonicNativePlugin {
    * @return {Observable<WebSocketMessage>}
    */
   watchMessage(): Observable<WebSocketMessage> {
-    return this.onFunctionToObservable("onMessage");
+    return this.onFunctionToObservable('onMessage');
   }
 
   /**
@@ -157,7 +157,7 @@ export class WebSocketServer extends IonicNativePlugin {
    * @return {Observable<WebSocketConnection>}
    */
   watchOpen(): Observable<WebSocketConnection> {
-    return this.onFunctionToObservable("onOpen");
+    return this.onFunctionToObservable('onOpen');
   }
 
   /**
@@ -165,7 +165,7 @@ export class WebSocketServer extends IonicNativePlugin {
    * @return {Observable<WebSocketClose>}
    */
   watchClose(): Observable<WebSocketClose> {
-    return this.onFunctionToObservable("onClose");
+    return this.onFunctionToObservable('onClose');
   }
 
   /**
@@ -173,7 +173,7 @@ export class WebSocketServer extends IonicNativePlugin {
    * @return {Observable<WebSocketFailure>}
    */
   watchFailure(): Observable<WebSocketFailure> {
-    return this.onFunctionToObservable("onFailure");
+    return this.onFunctionToObservable('onFailure');
   }
 
   /**

--- a/src/@ionic-native/plugins/web-socket-server/index.ts
+++ b/src/@ionic-native/plugins/web-socket-server/index.ts
@@ -69,17 +69,23 @@ export class WebSocketServer extends IonicNativePlugin {
     return;
   }
 
-  @Cordova()
+  @Cordova({
+      observable: true,
+  })
   onMessage(): Observable<WebSocketMessage> {
       return;
   }
 
-  @Cordova()
+  @Cordova({
+      observable: true,
+  })
   onOpen(): Observable<WebSocketConnection> {
       return;
   }
 
-  @Cordova()
+  @Cordova({
+      observable: true,
+  })
   onClose(): Observable<WebSocketClose> {
       return;
   }

--- a/src/@ionic-native/plugins/web-socket-server/index.ts
+++ b/src/@ionic-native/plugins/web-socket-server/index.ts
@@ -1,0 +1,74 @@
+/**
+ * This is a template for new plugin wrappers
+ *
+ * TODO:
+ * - Add/Change information below
+ * - Document usage (importing, executing main functionality)
+ * - Remove any imports that you are not using
+ * - Remove all the comments included in this template, EXCEPT the @Plugin wrapper docs and any other docs you added
+ * - Remove this note
+ *
+ */
+import { Injectable } from '@angular/core';
+import { Plugin, Cordova, CordovaProperty, CordovaInstance, InstanceProperty, IonicNativePlugin } from '@ionic-native/core';
+import { Observable } from 'rxjs';
+
+/**
+ * @name WebSocket Server
+ * @description
+ * This plugin does something
+ *
+ * @usage
+ * ```typescript
+ * import { WSServer } from '@ionic-native/ws-server';
+ *
+ *
+ * constructor(private wSServer: WSServer) { }
+ *
+ * ...
+ *
+ *
+ * this.wSServer.functionName('Hello', 123)
+ *   .then((res: any) => console.log(res))
+ *   .catch((error: any) => console.error(error));
+ *
+ * ```
+ */
+@Plugin({
+  pluginName: 'WebSocketServer',
+  plugin: 'cordova-plugin-websocket-server',
+  pluginRef: 'cordova.plugins.wsserver',
+  repo: 'https://github.com/becvert/cordova-plugin-websocket-server',
+  platforms: ['Android', 'iOS'],
+})
+@Injectable()
+export class WebSocketServer extends IonicNativePlugin {
+
+  @Cordova()
+  getInterfaces(): Promise<any> {
+    return;
+  }
+
+  @Cordova({
+      clearFunction: 'stop',
+  })
+  start(port: number, options: any): Promise<any> {
+    return;
+  }
+
+  @Cordova()
+  stop(): Promise<any> {
+    return;
+  }
+
+  @Cordova()
+  send(conn: any, msg: any): Promise<any> {
+    return;
+  }
+
+  @Cordova()
+  close(conn: any, code: any, reason: any): Promise<any> {
+    return;
+  }
+
+}

--- a/src/@ionic-native/plugins/web-socket-server/index.ts
+++ b/src/@ionic-native/plugins/web-socket-server/index.ts
@@ -9,9 +9,21 @@
  * - Remove this note
  *
  */
-import { Injectable } from '@angular/core';
-import { Plugin, Cordova, CordovaProperty, CordovaInstance, InstanceProperty, IonicNativePlugin } from '@ionic-native/core';
-import { Observable } from 'rxjs';
+import { Injectable } from "@angular/core";
+import {
+  Plugin,
+  Cordova,
+  CordovaProperty,
+  CordovaInstance,
+  InstanceProperty,
+  IonicNativePlugin
+} from "@ionic-native/core";
+import { Observable } from "rxjs";
+import { HttpdOptions } from "../httpd";
+import { Http2ServerRequest } from "http2";
+import { HTTPResponse } from "../http";
+import { DownloadHttpHeader } from "../downloader";
+import { UniqueDeviceID } from "../unique-device-id";
 
 /**
  * @name WebSocket Server
@@ -35,40 +47,113 @@ import { Observable } from 'rxjs';
  * ```
  */
 @Plugin({
-  pluginName: 'WebSocketServer',
-  plugin: 'cordova-plugin-websocket-server',
-  pluginRef: 'cordova.plugins.wsserver',
-  repo: 'https://github.com/becvert/cordova-plugin-websocket-server',
-  platforms: ['Android', 'iOS'],
+  pluginName: "WebSocketServer",
+  plugin: "cordova-plugin-websocket-server",
+  pluginRef: "cordova.plugins.wsserver",
+  repo: "https://github.com/becvert/cordova-plugin-websocket-server",
+  platforms: ["Android", "iOS"]
 })
 @Injectable()
 export class WebSocketServer extends IonicNativePlugin {
 
   @Cordova()
-  getInterfaces(): Promise<any> {
+  getInterfaces(): Promise<WebSocketInterfaces> {
     return;
   }
 
   @Cordova({
-      clearFunction: 'stop',
+    observable: true,
+    clearFunction: "stop",
   })
-  start(port: number, options: any): Promise<any> {
+  start(port: number, options: WebSocketOptions): Observable<WebSocketServerDetails> {
     return;
   }
 
   @Cordova()
-  stop(): Promise<any> {
+  onMessage(): Observable<WebSocketMessage> {
+      return;
+  }
+
+  @Cordova()
+  onOpen(): Observable<WebSocketConnection> {
+      return;
+  }
+
+  @Cordova()
+  onClose(): Observable<WebSocketClose> {
+      return;
+  }
+
+  @Cordova()
+  stop(): Promise<WebSocketServerDetails> {
     return;
   }
 
   @Cordova()
-  send(conn: any, msg: any): Promise<any> {
+  send(conn: WebSocketIdentifier, msg: string): Promise<any> {
     return;
   }
 
   @Cordova()
-  close(conn: any, code: any, reason: any): Promise<any> {
+  close(conn: WebSocketIdentifier, code: number, reason: string): Promise<any> {
     return;
   }
+}
 
+export type WebSocketInterfaces = {
+  [key: string]: WebSocketInterface;
+};
+
+export interface WebSocketInterface {
+  ipv4Addresses: string[];
+  ipv6Addresses: string[];
+}
+
+export interface WebSocketOptions {
+  origins?: string[];
+  protocols?: string[];
+  tcpNoDelay?: boolean;
+}
+
+export interface WebSocketIdentifier {
+    uuid: string;
+}
+
+export interface WebSocketServerDetails {
+    addr: string;
+    port: number;
+}
+
+export interface WebSocketMessage {
+    conn: WebSocketConnection;
+    msg: string;
+}
+
+export interface WebSocketClose {
+    conn: WebSocketConnection;
+    code: number;
+    reason: string;
+    wasClean: boolean;
+}
+
+export interface WebSocketConnection extends WebSocketIdentifier {
+    remoteAttr: string;
+    state: 'open' | 'closed';
+    httpFields: HttpFields;
+    resource: string;
+}
+
+export interface HttpFields {
+    'Accept-Encoding': string;
+    'Accept-Language': string;
+    'Cache-Control': string;
+    Connection: string;
+    Host: string;
+    Origin: string;
+    Pragma: string;
+    'Sec-WebSocket-Extensions': string;
+    'Sec-WebSocket-Key': string;
+    'Sec-WebSocket-Version': string;
+    Upgrade: string;
+    'User-Agent': string;
 }

--- a/src/@ionic-native/plugins/web-socket-server/index.ts
+++ b/src/@ionic-native/plugins/web-socket-server/index.ts
@@ -178,7 +178,7 @@ export class WebSocketServer extends IonicNativePlugin {
 
   /**
    * Stop websocket server and closes all connections
-   * @return {Promise<WebSocketServerDetails}
+   * @return {Promise<WebSocketServerDetails>}
    */
   @Cordova()
   stop(): Promise<WebSocketServerDetails> {


### PR DESCRIPTION
This PR adds cordova-plugin-websocket-server for Android and iOS. I have tested it on Android but not iOS, since I have no iPhone or Mac.

Also this plugin relies on this PR https://github.com/becvert/cordova-plugin-websocket-server/pull/64. If it does not get accepted I could also change the link to my fork.