### PR TITLE
fix(web-server): add path to response

### DIFF
--- a/src/@ionic-native/plugins/web-server/index.ts
+++ b/src/@ionic-native/plugins/web-server/index.ts
@@ -4,7 +4,8 @@ import { Observable } from 'rxjs';
 
 export interface Response {
   status: number;
-  body: string;
+  body?: string;
+  path?: string;
   headers: { [key: string]: string};
 }
 


### PR DESCRIPTION
Partially fixes #3126. It does not fix the wrong npm entry.

I have added optional body and path to the response type. Since path is supported by the cordova plugin. 