### PR TITLE
docs(camera): PictureSourceType switched?

### DIFF
--- a/src/@ionic-native/plugins/camera/index.ts
+++ b/src/@ionic-native/plugins/camera/index.ts
@@ -211,11 +211,11 @@ export class Camera extends IonicNativePlugin {
    * Convenience constant
    */
   PictureSourceType = {
-    /** Choose image from picture library (same as SAVEDPHOTOALBUM for Android) */
+    /** Choose image from picture library (same as PHOTOLIBRARY for Android) */
     PHOTOLIBRARY: 0,
     /** Take picture from camera */
     CAMERA: 1,
-    /** Choose image from picture library (same as PHOTOLIBRARY for Android) */
+    /** Choose image from picture library (same as SAVEDPHOTOALBUM for Android) */
     SAVEDPHOTOALBUM: 2
   };
 


### PR DESCRIPTION
It seems like these two definitions were switched around accidentally. I'm just going from the obvious logic of it. I don't know if there is some situation where the names are intentionally switched around? Please only accept PR if you can vouch for my change.