### PR TITLE
feat(secure-storage-echo): added wrapper to newest plugin

### DIFF
--- a/src/@ionic-native/plugins/secure-storage-echo/index.ts
+++ b/src/@ionic-native/plugins/secure-storage-echo/index.ts
@@ -1,0 +1,149 @@
+import { Injectable } from '@angular/core';
+import { CordovaCheck, CordovaInstance, IonicNativePlugin, Plugin, getPromise } from '@ionic-native/core';
+
+/**
+ * @hidden
+ */
+export class SecureStorageEchoObject {
+  constructor(private _objectInstance: any) {}
+
+  /**
+   * Gets a stored item
+   * @param key {string}
+   * @returns {Promise<string>}
+   */
+  @CordovaInstance({
+    callbackOrder: 'reverse'
+  })
+  get(key: string): Promise<string> {
+    return;
+  }
+
+  /**
+   * Stores a value
+   * @param key {string}
+   * @param value {string}
+   * @returns {Promise<any>}
+   */
+  @CordovaInstance({
+    callbackOrder: 'reverse'
+  })
+  set(key: string, value: string): Promise<any> {
+    return;
+  }
+
+  /**
+   * Removes a single stored item
+   * @param key {string}
+   * @returns {Promise<string>} returns a promise that resolves with the key that was removed
+   */
+  @CordovaInstance({
+    callbackOrder: 'reverse'
+  })
+  remove(key: string): Promise<string> {
+    return;
+  }
+
+  /**
+   * Get all references from the storage.
+   * @returns {Promise<string[]>} returns a promise that resolves with array of keys storage
+   */
+  @CordovaInstance({
+    callbackOrder: 'reverse'
+  })
+  keys(): Promise<string[]> {
+    return;
+  }
+
+  /**
+   * Clear all references from the storage.
+   * @returns {Promise<any>}
+   */
+  @CordovaInstance({
+    callbackOrder: 'reverse'
+  })
+  clear(): Promise<any> {
+    return;
+  }
+
+  /**
+   * Brings up the screen-lock settings
+   * @returns {Promise<any>}
+   */
+  @CordovaInstance()
+  secureDevice(): Promise<any> {
+    return;
+  }
+}
+
+/**
+ * @name Secure Storage Echo
+ * @description
+ * This plugin gets, sets and removes key,value pairs from a device's secure storage.
+ *
+ * Requires Cordova plugin: `cordova-plugin-secure-storage-echo`. For more info, please see the [Cordova Secure Storage docs](https://github.com/mibrito707/cordova-plugin-secure-storage-echo).
+ *
+ * The browser platform is supported as a mock only. Key/values are stored unencrypted in localStorage.
+ *
+ * @usage
+ *
+ * ```typescript
+ * import { SecureStorageEcho, SecureStorageEchoObject } from '@ionic-native/secure-storage-echo/ngx';
+ *
+ * constructor(private secureStorageEcho: SecureStorageEcho) { }
+ *
+ * ...
+ *
+ * this.secureStorageEcho.create('my_store_name')
+ *   .then((storage: SecureStorageEchoObject) => {
+ *
+ *      storage.get('key')
+ *        .then(
+ *          data => console.log(data),
+ *          error => console.log(error)
+ *      );
+ *
+ *      storage.set('key', 'value')
+ *        .then(
+ *         data => console.log(data),
+ *          error => console.log(error)
+ *      );
+ *
+ *      storage.remove('key')
+ *      .then(
+ *          data => console.log(data),
+ *          error => console.log(error)
+ *      );
+ *
+ *   });
+ *
+ *
+ * ```
+ * @classes
+ * SecureStorageEchoObject
+ */
+@Plugin({
+  pluginName: 'SecureStorageEcho',
+  plugin: 'cordova-plugin-secure-storage-echo',
+  pluginRef: 'cordova.plugins.SecureStorage',
+  repo: 'https://github.com/mibrito707/cordova-plugin-secure-storage-echo',
+  platforms: ['Android', 'Browser', 'iOS', 'Windows']
+})
+@Injectable()
+export class SecureStorageEcho extends IonicNativePlugin {
+  /**
+   * Creates a namespaced storage.
+   * @param store {string}
+   * @returns {Promise<SecureStorageEchoObject>}
+   */
+  @CordovaCheck()
+  create(store: string): Promise<SecureStorageEchoObject> {
+    return getPromise<SecureStorageEchoObject>((res: Function, rej: Function) => {
+      const instance = new (SecureStorageEcho.getPlugin())(
+        () => res(new SecureStorageEchoObject(instance)),
+        rej,
+        store
+      );
+    });
+  }
+}


### PR DESCRIPTION
In some projects I am working on, there are certain incompatibilities with Android Q/10 that It is fixed bt another Cordova plugin. I have created a new wrapper for that plugin can be used and we can start our Apps without problems. I don't know if this plugin is merged with the current one, so for security and necessity for the majority of developers who use this plugin, I think it is a good opportunity to contribute my grain of sand with this wrapper 😆.

Greetings!

EDIT: The current plugin is no longer mantained