### PR TITLE
feat(Sign in with Apple): Added Sign in with Apple

### DIFF
--- a/src/@ionic-native/plugins/sign-in-with-apple/index.ts
+++ b/src/@ionic-native/plugins/sign-in-with-apple/index.ts
@@ -1,0 +1,138 @@
+import { Injectable } from '@angular/core';
+import { Plugin, Cordova, IonicNativePlugin } from '@ionic-native/core';
+
+export interface AppleSignInResponse {
+  /**
+   * E-Mail address i.e. abc@privaterelay.appleid.com
+   */
+  email?: string;
+
+  /**
+   * The state (could be empty)
+   */
+  state?: string;
+
+  /**
+   * The identity token
+   */
+  identityToken: string;
+
+  /**
+   * Name details of the user
+   */
+  fullName?: {
+    /**
+     * The nickname of the user (could be empty)
+     */
+    nickname?: string;
+
+    /**
+     * The phonetic representation of the user (could be an empty object)
+     */
+    phoneticRepresentation?: {};
+
+    /**
+     * The family name of the user (i.e. Doe)
+     */
+    familyName?: string;
+
+    /**
+     * The name prefix of the user (could be an empty object)
+     */
+    namePrefix?: string;
+
+    /**
+     * The given name of the user (i.e. John)
+     */
+    givenName?: string;
+
+    /**
+     * The name suffix of the user (could be an empty object)
+     */
+    nameSuffix?: string;
+  };
+
+  /**
+   * The user i.e. 001234.1a11b111c1111d111111e111111f1111.1234
+   */
+  user?: string;
+}
+
+export interface AppleSignInErrorResponse {
+  /**
+   * Error code i.e. 1000
+   */
+  code?: number;
+
+  /**
+   * The localized failure reason, could be empty
+   */
+  localizedFailureReason?: string;
+
+  /**
+   * The error i.e. "ASAUTHORIZATION_ERROR"
+   */
+  error?: string;
+
+  /**
+   * The localized description of the error
+   */
+  localizedDescription?: string;
+}
+
+/**
+ * @name Sign In With Apple
+ * @description
+ * Sign in with Apple makes it easy for users to sign in to your apps and websites using their Apple ID.
+ * Instead of filling out forms, verifying email addresses, and choosing new passwords,
+ * they can use Sign in with Apple to set up an account and start using your app right away.
+ * All accounts are protected with two-factor authentication for superior security,
+ * and Apple will not track users’ activity in your app or website.
+ * *Source:* https://developer.apple.com/sign-in-with-apple/
+ *
+ * @usage
+ * ```typescript
+ * import { SignInWithApple, AppleSignInResponse, AppleSignInErrorResponse } from '@ionic-native/sign-in-with-apple/ngx';
+ *
+ *
+ * constructor(private signInWithApple: SignInWithApple) { }
+ *
+ * ...
+ *
+ *
+ * this.signInWithApple.signin()
+ *   .then((res: AppleSignInResponse) => {
+ *     // https://developer.apple.com/documentation/signinwithapplerestapi/verifying_a_user
+ *     alert('Send token to apple for verification: ' + res.identityToken);
+ *     console.log(res);
+ *   })
+ *   .catch((error: AppleSignInErrorResponse) => {
+ *     alert(error.code + ' ' + error.localizedDescription);
+ *     console.error(error);
+ *   });
+ *
+ * ```
+ */
+@Plugin({
+  pluginName: 'Sign in with Apple',
+  plugin: 'cordova-plugin-sign-in-with-apple',
+  pluginRef: 'cordova.plugins.SignInWithApple',
+  repo: 'https://github.com/twogate/cordova-plugin-sign-in-with-apple',
+  platforms: ['iOS']
+})
+@Injectable()
+export class SignInWithApple extends IonicNativePlugin {
+
+  /**
+   * Starts the authorization flows named during controller initialization
+   * @see https://developer.apple.com/documentation/authenticationservices/asauthorizationcontroller/3153047-performrequests
+   * @return {Promise<AppleSignInResponse>} Returns a promise when authorization succeeds
+   * @param arg0
+   * @throws AppleSignInErrorResponse
+   */
+  @Cordova()
+  signin(arg0: object = null): Promise<AppleSignInResponse> {
+    return;
+  }
+
+}

--- a/src/@ionic-native/plugins/sign-in-with-apple/index.ts
+++ b/src/@ionic-native/plugins/sign-in-with-apple/index.ts
@@ -1,83 +1,107 @@
 import { Injectable } from '@angular/core';
 import { Plugin, Cordova, IonicNativePlugin } from '@ionic-native/core';
 
+/**
+ * @see https://developer.apple.com/documentation/foundation/nspersonnamecomponents/1412193-phoneticrepresentation
+ */
+export interface NSPersonNameComponents {
+  /**
+   * The portion of a name’s full form of address that precedes the name itself (for example, "Dr.," "Mr.," "Ms.")
+   */
+  namePrefix?: string;
+
+  /**
+   * Name bestowed upon an individual to differentiate them from other members of a group that share a family name (for example, "Johnathan")
+   */
+  givenName?: string;
+
+  /**
+   * Secondary name bestowed upon an individual to differentiate them from others that have the same given name (for example, "Maple")
+   */
+  middleName?: string;
+
+  /**
+   * Name bestowed upon an individual to denote membership in a group or family. (for example, "Appleseed")
+   */
+  familyName?: string;
+
+  /**
+   * The portion of a name’s full form of address that follows the name itself (for example, "Esq.," "Jr.," "Ph.D.")
+   */
+  nameSuffix?: string;
+
+  /**
+   * Name substituted for the purposes of familiarity (for example, "Johnny")
+   */
+  nickname?: string;
+
+  /**
+   * The phonetic representation name components of the receiver
+   */
+  phoneticRepresentation?: NSPersonNameComponents;
+}
+
+/**
+ * @see https://developer.apple.com/documentation/authenticationservices/asauthorizationappleidcredential
+ */
 export interface AppleSignInResponse {
   /**
-   * E-Mail address i.e. abc@privaterelay.appleid.com
+   * The user’s email address i.e. abc@privaterelay.appleid.com
    */
   email?: string;
 
   /**
-   * The state (could be empty)
+   * An arbitrary string that your app provided to the request that generated the credential
    */
   state?: string;
 
   /**
-   * The identity token
+   * A JSON Web Token (JWT) that securely communicates information about the user to your app
    */
   identityToken: string;
 
   /**
-   * Name details of the user
+   * A short-lived token used by your app for proof of authorization when interacting with the app's server counterpart
    */
-  fullName?: {
-    /**
-     * The nickname of the user (could be empty)
-     */
-    nickname?: string;
-
-    /**
-     * The phonetic representation of the user (could be an empty object)
-     */
-    phoneticRepresentation?: {};
-
-    /**
-     * The family name of the user (i.e. Doe)
-     */
-    familyName?: string;
-
-    /**
-     * The name prefix of the user (could be an empty object)
-     */
-    namePrefix?: string;
-
-    /**
-     * The given name of the user (i.e. John)
-     */
-    givenName?: string;
-
-    /**
-     * The name suffix of the user (could be an empty object)
-     */
-    nameSuffix?: string;
-  };
+  authorizationCode: string;
 
   /**
-   * The user i.e. 001234.1a11b111c1111d111111e111111f1111.1234
+   * The user's name
+   * @see https://developer.apple.com/documentation/foundation/nspersonnamecomponents?language=objc
+   */
+  fullName?: NSPersonNameComponents;
+
+  /**
+   * An identifier associated with the authenticated user
    */
   user?: string;
 }
 
-export interface AppleSignInErrorResponse {
+/**
+ * @see https://developer.apple.com/documentation/foundation/nserror
+ */
+export interface NSError {
   /**
-   * Error code i.e. 1000
+   * The error code
    */
   code?: number;
 
   /**
-   * The localized failure reason, could be empty
+   * A string containing the localized description of the error
+   */
+  localizedDescription?: string;
+
+  /**
+   * A string containing the localized explanation of the reason for the error
    */
   localizedFailureReason?: string;
+}
 
+export interface AppleSignInErrorResponse extends NSError {
   /**
    * The error i.e. "ASAUTHORIZATION_ERROR"
    */
   error?: string;
-
-  /**
-   * The localized description of the error
-   */
-  localizedDescription?: string;
 }
 
 /**


### PR DESCRIPTION
I added the wrapper for the cordova plugin:
https://www.npmjs.com/package/cordova-plugin-sign-in-with-apple

With this we can use Apple's new sign in with Apple function with Ionic Native 🥳
https://developer.apple.com/sign-in-with-apple/