### PR TITLE
fix(keyboard): Add missing CordovaProperty import

### DIFF
--- a/src/@ionic-native/plugins/keyboard/index.ts
+++ b/src/@ionic-native/plugins/keyboard/index.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { Cordova, IonicNativePlugin, Plugin } from '@ionic-native/core';
+import { Cordova, IonicNativePlugin, CordovaProperty, Plugin } from '@ionic-native/core';
 import { Observable } from 'rxjs';
 
 export enum KeyboardStyle {


### PR DESCRIPTION
Somehow, the Keyboard plugin was updated/merged into master with a missing import statement.

Without it, running the `docs-json` script fails. 