### PR TITLE
feat(fcm): add getAPNSToken method

### DIFF
--- a/src/@ionic-native/plugins/fcm/index.ts
+++ b/src/@ionic-native/plugins/fcm/index.ts
@@ -71,6 +71,16 @@ export class FCM extends IonicNativePlugin {
   getToken(): Promise<string> {
     return;
   }
+  
+  /**
+   * Gets ios device's current APNS registration id
+   *
+   * @returns {Promise<string>} Returns a Promise that resolves with the APNS registration id token
+   */
+  @Cordova()
+  getAPNSToken(): Promise<string> {
+    return;
+  }
 
   /**
    * Event firing on the token refresh


### PR DESCRIPTION
New version of `cordova-plugin-fcm-with-dependecy-updated` released: v4.0.0

_“The old FCMPlugin.getToken is focused on retrieving the FCM Token. For the IOS, APNS token can now be retrieved by the new method”_ [Show readme](https://github.com/andrehtissot/cordova-plugin-fcm-with-dependecy-updated#version-400-12102019).