### PR TITLE
feat(fcm): add hasPermission method 

### DIFF
--- a/src/@ionic-native/plugins/fcm/index.ts
+++ b/src/@ionic-native/plugins/fcm/index.ts
@@ -71,6 +71,19 @@ export class FCM extends IonicNativePlugin {
   getToken(): Promise<string> {
     return;
   }
+  
+  /**
+   * Checking for permissions. Useful for IOS. On android, it will always return true.
+   *
+   * @returns {Promise<boolean | null>} Returns a Promise: 
+   * - true: push was allowed
+   * - false: push will not be available
+   * - null: still not answered, recommended checking again later.
+   */
+  @Cordova()
+  hasPermission(): Promise<boolean | null> {
+    return;
+  }
 
   /**
    * Event firing on the token refresh


### PR DESCRIPTION
[Show readme.md](https://github.com/andrehtissot/cordova-plugin-fcm-with-dependecy-updated#version-320-16092019)  

#### Checking for permissions
Useful for IOS. On android, it will always return `true`.

```javascript
FCMPlugin.hasPermission(function(doesIt){
    // doesIt === true => yes, push was allowed
    // doesIt === false => nope, push will not be available
    // doesIt === null => still not answered, recommended checking again later
    if(doesIt) {
        haveFun();
    }
});
```