### PR TITLE
feat(pspdfkit-cordova): add PSPDFKit-Cordova plugin

### DIFF
--- a/src/@ionic-native/plugins/pspdfkit-cordova/index.ts
+++ b/src/@ionic-native/plugins/pspdfkit-cordova/index.ts
@@ -1,0 +1,629 @@
+import { Injectable } from '@angular/core';
+import { Plugin, Cordova, CordovaProperty, CordovaInstance, InstanceProperty, IonicNativePlugin } from '@ionic-native/core';
+import { Observable } from 'rxjs';
+
+/**
+ * @name PSPDFKit-Cordova
+ * @description
+ * The official plugin to use PSPDFKit with Cordova and Ionic.
+ *
+ * @usage
+ * ```typescript
+ * import { PSPDFKit } from '@ionic-native/pspdfkit-cordova/ngx';
+ *
+ *
+ * constructor(private pspdfkit: PSPDFKit) { }
+ *
+ * ...
+ *
+ * // Set your license key here.
+ * this.pspdfkit.setLicenseKey("YOUR KEY");
+ *
+ * // Show a PDF in single page mode, with a black background.
+ * this.pspdfkit.present('document.pdf', {pageMode: 'single', backgroundColor: "black"})
+ *   .then(result => {
+ *      console.log(result); // Success
+ *   })
+ *   .catch(error => {
+ *      console.log(error); // Failed
+ *   });
+ * }
+ *
+ * // Scroll to page at index 1.
+ * this.pspdfkit.setPage(1, true);
+ *
+ * ```
+ */
+@Plugin({
+  pluginName: 'PSPDFKit',
+  plugin: 'pspdfkit-cordova',
+  pluginRef: 'PSPDFKit',
+  repo: 'https://github.com/PSPDFKit/PSPDFKit-Cordova',
+  install: 'ionic cordova plugin add pspdfkit-cordova',
+  platforms: ['Android', 'iOS']
+})
+@Injectable()
+export class PSPDFKit extends IonicNativePlugin {
+
+ /**
+  * Activates PSPDFKit with your license key from https://customers.pspdfkit.com.
+  *
+  * @param key {string} The license key.
+  * @return {Promise<any>} Success and error callback function.
+  *
+  * __Supported Platforms__
+  *
+  * -iOS
+  */
+  @Cordova()
+  setLicenseKey(licenseKey: string): Promise<any> {
+    return;
+  }
+
+ /**
+  * iOS: Displays a PDF in a full-screen modal.
+  * Android: Opens the PSPDFActivity to show a document from the local device file system.
+  *
+  * @param path {string} The path should be a string containing the file path (not URL) for the PDF. Relative paths are assumed to be relative to the www directory (if the path has a different base URL set, this will be ignored). To specify a path inside the application documents or library directory, use a `~`, e.g. `"~/Documents/mypdf.pdf"` or `"~/Library/Application Support/mypdf.pdf"`. Path can be null, but must not be omitted
+  * @param options {any} The `options` parameter is an optional object containing configuration properties for the PDF document and/or view controller. All currently supported values are listed below under Options.
+  * @return {Promise<any>} callback Success (or result) and error callback function.
+  *
+  * __Supported Platforms__
+  *
+  * -iOS
+  * -Android
+  */
+  @Cordova()
+  present(path: string, options?: any): Promise<any> {
+    return;
+  }
+
+ /**
+  * Opens the PSPDFActivity to show a document from the app's assets folder. This method copies the
+  * file to the internal app directory on the device before showing it.
+  * @param assetFile {string} Relative path within the app's assets folder.
+  * @param options {any} PSPDFKit configuration options.
+  * @return {Promise<any>} callback Success (or result) and error callback function.
+  *
+  * __Supported Platforms__
+  *
+  * -Android
+  */
+  @Cordova()
+  presentFromAssets(assetFile: string, options?: any): Promise<any> {
+    return;
+  }
+
+ /**
+  * Displays a PDF in a full-screen modal and imports annotations from a given XFDF file.
+  *
+  * @param path {string} Should be a string containing the file path (not URL) for the PDF. Relative paths are assumed to be relative to the www directory (if the path has a different base URL set, this will be ignored). To specify a path inside the application documents or library directory, use a `~`, e.g. `"~/Documents/mypdf.pdf"` or `"~/Library/Application Support/mypdf.pdf"`. Path can be null, but must not be omitted
+  * @param xfdfPath {string} should be a string containing the file path (not URL) for the XFDF file backing the PDF document. Relative paths are assumed to be relative to the www directory (if the xfdf path has a different base URL set, we will create an XFDF file in `'"~/Documents/" + xfdfPath'`). To specify a path inside the application documents or library directory, use a ~, e.g. `"~/Documents/myXFDF.xfdf"` or `"~/Library/Application Support/myXFDF.xfdf"`. The xfdfPath cannot be null and must not be omitted.
+  * @param options {any} The `options` parameter is an optional object containing configuration properties for the PDF document and/or view controller. All currently supported values are listed below under Options.
+  * @return {Promise<any>} callback Success (or result) and error callback function.
+  *
+  * __Supported Platforms__
+  *
+  * -iOS
+  */
+  @Cordova()
+  presentWithXFDF(path: string, xfdfPath: string, options?: any): Promise<any> {
+    return;
+  }
+
+ /**
+  * iOS: Dismisses the modally presented PDF view.
+  * Android: Dismisses any previously launched PDF activity. Calls the optional callback function after all activities have been dismissed.
+  *
+  * @return {Promise<any>} callback Success (or result) and error callback function.
+  *
+  * __Supported Platforms__
+  *
+  * -iOS
+  * -Android
+  */
+  @Cordova()
+  dismiss(): Promise<any> {
+    return;
+  }
+
+ /**
+  * Reloads the current PDF.
+  *
+  * @return {Promise<any>} callback Success (or result) and error callback function.
+  *
+  * __Supported Platforms__
+  *
+  * -iOS
+  */
+  @Cordova()
+  reload(): Promise<any> {
+    return;
+  }
+ /**
+  * Saves the document to original location if it has been changed. If there were no changes to the
+  * document, the document file will not be modified.
+  * Provides "wasModified" as a part of a successful response which will be equal to true if
+  * the file was modified and changes were saved. false if there was nothing to save.
+  *
+  * @return {Promise<any>} callback Success (or result) and error callback function.
+  *
+  * __Supported Platforms__
+  *
+  * -Android
+  */
+  @Cordova()
+  saveDocument(): Promise<any> {
+    return;
+  }
+
+ /**
+  * Saves any changed annotations in the current document.
+  *
+  * @return {Promise<any>} callback Success (or result) and error callback function.
+  *
+  * __Supported Platforms__
+  *
+  * -iOS
+  */
+  @Cordova()
+  saveAnnotations(): Promise<any> {
+    return;
+  }
+
+ /**
+  * Return true in the success (or result) callback if the document has unsaved annotation. Returns false otherwise.
+  *
+  * @return {Promise<any>} callback Success (or result) and error callback function.
+  *
+  * __Supported Platforms__
+  *
+  * -iOS
+  * -Android
+  */
+  @Cordova()
+  getHasDirtyAnnotations(): Promise<any> {
+    return;
+  }
+
+ /**
+  * Triggers a search for the specified query.
+  *
+  * @param query {string} Search Term to query
+  * @param animated {boolean} Determines if the search should be animated (if omitted, the search will not be animated). The optional headless argument determines whether the search UI should be disaplyed (if omitted, the search UI *will* be displayed).
+  * @param headless {boolean} Determines whether the search UI should be disaplyed (if omitted, the search UI *will* be displayed).
+  * @return {Promise<any>} callback Success (or result) and error callback function.
+  *
+  * __Supported Platforms__
+  *
+  * -iOS
+  */
+  @Cordova()
+  search(query: string, animated?: boolean, headless?: boolean): Promise<any> {
+    return;
+  }
+
+ /**
+  * Sets multiple document and view controller settings at once.
+  *
+  * @param options {any} The options set will be applied to the current document (if there is one) as well as all subsequently displayed documents. All currently supported values are listed below under Options.
+  * @param animated {boolean} determines if the property should be animated. Not all property changes can be animated, so if the property does not support animation the animated argument will be ignored.
+  * @return {Promise<any>} callback Success (or result) and error callback function.
+  *
+  * __Supported Platforms__
+  *
+  * -iOS
+  */
+  @Cordova()
+  setOptions(options: any, animated: boolean): Promise<any> {
+    return;
+  }
+
+ /**
+  * Gets several document or view controller options in a single call.
+  *
+  * @param names {[any]} array of option names
+  * @return {Promise<any>} callback Success (or result) and error callback function.
+  *
+  * __Supported Platforms__
+  *
+  * -iOS
+  */
+  @Cordova()
+  getOptions(names: [any]): Promise<any> {
+    return;
+  }
+
+ /**
+  * Sets a single document or view controller settings at once.
+  *
+  * @param name {string} the option name
+  * @param value {any} the option value
+  * @param animated {boolean} determines if the property should be animated. Not all property changes can be animated, so if the property does not support animation the animated argument will be ignored.
+  * @return {Promise<any>} callback Success (or result) and error callback function.
+  *
+  * __Supported Platforms__
+  *
+  * -iOS
+  */
+  @Cordova()
+  setOption(name: string, value: any, animated: boolean): Promise<any> {
+    return;
+  }
+
+ /**
+  * Gets a single document or view controller settings at once.
+  *
+  * @param name {string} the option name
+  * @return {Promise<any>} callback Success (or result) and error callback function.
+  *
+  * __Supported Platforms__
+  *
+  * -iOS
+  */
+  @Cordova()
+  getOption(name: string): Promise<any> {
+    return;
+  }
+
+ /**
+  * Sets the current visible page.
+  *
+  * @param page {number} the page index
+  * @param animated {boolean} Optional argument. Determines if the page change should be animated (if omitted, the search will not be animated).
+  * @return {Promise<any>} callback Success (or result) and error callback function.
+  *
+  * __Supported Platforms__
+  *
+  * -iOS
+  */
+  @Cordova()
+  setPage(page: number, animated?: boolean): Promise<any> {
+    return;
+  }
+
+ /**
+  * Gets the currently visible page.
+  *
+  * @return {Promise<any>} callback Success (or result) and error callback function.
+  *
+  * __Supported Platforms__
+  *
+  * -iOS
+  */
+  @Cordova()
+  getPage(): Promise<any> {
+    return;
+  }
+
+ /**
+  * Gets the page count of the current document.
+  *
+  * @return {Promise<any>} callback Success (or result) and error callback function.
+  *
+  * __Supported Platforms__
+  *
+  * -iOS
+  */
+  @Cordova()
+  getPageCount(): Promise<any> {
+    return;
+  }
+
+ /**
+  * Scrolls to the next page.
+  *
+  * @param animated {boolean} Optional argument. Determines if the page change should be animated (if omitted, the search will not be animated).
+  * @return {Promise<any>} callback Success (or result) and error callback function.
+  *
+  * __Supported Platforms__
+  *
+  * -iOS
+  */
+  @Cordova()
+  scrollToNextPage(animated?: boolean): Promise<any> {
+    return;
+  }
+
+ /**
+  * Scrolls to the previous page.
+  *
+  * @param animated {boolean} Optional argument. Determines if the page change should be animated (if omitted, the search will not be animated).
+  * @return {Promise<any>} callback Success (or result) and error callback function.
+  *
+  * __Supported Platforms__
+  *
+  * -iOS
+  */
+  @Cordova()
+  scrollToPreviousPage(animated?: boolean): Promise<any> {
+    return;
+  }
+
+ /**
+  * Sets the appearance mode.
+  *
+  * @param appearanceMode {string} the appearance mode. Can be 'default', 'sepia', or 'night'
+  * @return {Promise<any>} callback Success (or result) and error callback function.
+  *
+  * __Supported Platforms__
+  *
+  * -iOS
+  */
+  @Cordova()
+  setAppearanceMode(appearanceMode: string): Promise<any> {
+    return;
+  }
+
+ /**
+  * Clears the entire render cache. This invalidates render caches for all previously rendered documents.
+  * Consider using `removeCacheForPresentedDocument()` or `clearCacheForPage()` instead of this,
+  * since invalidating single documents or specific page caches since excessive cache invalidation may decrease performance.
+  *
+  * @param clearDiskCache {boolean} optional parameter. Android: if set to true clears disk cache as well. iOS: has no effect.
+  * @return {Promise<any>} callback Success (or result) and error callback function.
+  *
+  * __Supported Platforms__
+  *
+  * -iOS
+  * -Android
+  */
+  @Cordova()
+  clearCache(clearDiskCache?: boolean): Promise<any> {
+    return;
+  }
+
+ /**
+  * Clears the cache from the currently presented document.
+  *
+  * @return {Promise<any>} callback Success (or result) and error callback function.
+  *
+  * __Supported Platforms__
+  *
+  * -iOS
+  * -Android
+  */
+  @Cordova()
+  removeCacheForPresentedDocument(): Promise<any> {
+    return;
+  }
+
+ /**
+  * Invalidates the render cache for the specified page.
+  *
+  * @param pageIndex {number} 0-based index of the page whose render cache should be invalidated.
+  * @return {Promise<any>} callback Success (or result) and error callback function.
+  *
+  * __Supported Platforms__
+  *
+  * -Android
+  */
+  @Cordova()
+  clearCacheForPage(pageIndex: number): Promise<any> {
+    return;
+  }
+
+ /**
+  * Hides the annotation toolbar
+  *
+  * @return {Promise<any>} callback Success (or result) and error callback function.
+  *
+  * __Supported Platforms__
+  *
+  * -iOS
+  */
+  @Cordova()
+  hideAnnotationToolbar(): Promise<any> {
+    return;
+  }
+
+ /**
+  * Shows the annotation toolbar
+  *
+  * @return {Promise<any>} callback Success (or result) and error callback function.
+  *
+  * __Supported Platforms__
+  *
+  * -iOS
+  */
+  @Cordova()
+  showAnnotationToolbar(): Promise<any> {
+    return;
+  }
+
+ /**
+  * Toggles the annotation toolbar
+  *
+  * @return {Promise<any>} callback Success (or result) and error callback function.
+  *
+  * __Supported Platforms__
+  *
+  * -iOS
+  */
+  @Cordova()
+  toggleAnnotationToolbar(): Promise<any> {
+    return;
+  }
+
+ /**
+  * Applies the passed in document Instant JSON.
+  *
+  * @param jsonValue {string} The document Instant JSON to apply.
+  * @return {Promise<any>} callback Success (or result) and error callback function.
+  *
+  * __Supported Platforms__
+  *
+  * -iOS
+  * -Android
+  */
+  @Cordova()
+  applyInstantJSON(jsonValue: string): Promise<any> {
+    return;
+  }
+
+ /**
+  * Adds a new annotation to the current document using the Instant JSON Annotation
+  * payload - https://pspdfkit.com/guides/ios/current/importing-exporting/instant-json/#instant-annotation-json-api
+  *
+  * @param jsonAnnotation {string} Instant JSON of the annotation to add.
+  * @return {Promise<any>} callback Success (or result) and error callback function.
+  *
+  * __Supported Platforms__
+  *
+  * -iOS
+  * -Android
+  */
+  @Cordova()
+  addAnnotation(jsonAnnotation: string): Promise<any> {
+    return;
+  }
+
+ /**
+  * Removes a given annotation from the current document.  The annotaion is expected to be in Instant
+  * JSON format - https://pspdfkit.com/guides/ios/current/importing-exporting/instant-json/#instant-annotation-json-api
+  *
+  * @param jsonAnnotation {string} Instant JSON of the annotation to remove.
+  * @return {Promise<any>} callback Success (or result) and error callback function.
+  *
+  * __Supported Platforms__
+  *
+  * -iOS
+  * -Android
+  */
+  @Cordova()
+  removeAnnotation(jsonAnnotation: string): Promise<any> {
+    return;
+  }
+
+ /**
+  * Gets all annotations of the given type from the page.
+  *
+  * @param pageIndex {number} The page to get the annotations for.
+  * @param type {string} The type of annotations to get (See here for types https://pspdfkit.com/guides/server/current/api/json-format/) or `null` to get all annotations.
+  * @return {Promise<any>} callback Success (or result) and error callback function.
+  *
+  * __Supported Platforms__
+  *
+  * -iOS
+  * -Android
+  */
+  @Cordova()
+  getAnnotations(pageIndex: number, type?: string): Promise<any> {
+    return;
+  }
+
+ /**
+  * Gets all unsaved changes to annotations.
+  *
+  * @return {Promise<any>} callback Success (or result) and error callback function.
+  *
+  * __Supported Platforms__
+  *
+  * -iOS
+  * -Android
+  */
+  @Cordova()
+  getAllUnsavedAnnotations(): Promise<any> {
+    return;
+  }
+
+ /**
+  * Sets the value of the form element of the fully qualified name.
+  *
+  * @param value {string} the value.
+  * @param fullyQualifiedName {string} the fully qualified name of the form element.
+  * @return {Promise<any>} callback Success (result) and error callback function.
+  *
+  * __Supported Platforms__
+  *
+  * -iOS
+  * -Android
+  */
+  @Cordova()
+  setFormFieldValue(value: string, fullyQualifiedName: string): Promise<any> {
+    return;
+  }
+
+ /**
+  * Gets the value of the form element of the fully qualified name.
+  *
+  * @param fullyQualifiedName {string} description.
+  * @return {Promise<any>} callback Success (result) and error callback function.
+  *
+  * __Supported Platforms__
+  *
+  * -iOS
+  * -Android
+  */
+  @Cordova()
+  getFormFieldValue(fullyQualifiedName: string): Promise<any> {
+    return;
+  }
+
+ /**
+  * Imports all annotations from the specified XFDF file to the current document.
+  *
+  * @param xfdfPath {string} XFDF file path to import annotations
+  * @return {Promise<any>} callback Success (or result) and error callback function.
+  *
+  * __Supported Platforms__
+  *
+  * -iOS
+  * -Android
+  */
+  @Cordova()
+  importXFDF(xfdfPath: string): Promise<any> {
+    return;
+  }
+
+ /**
+  * Exports all annotations from the current document to the specified XFDF file path.
+  *
+  * @param xfdfPath {string} XFDF file path to export annotations
+  * @return {Promise<any>} callback Success (or result) and error callback function.
+  *
+  * __Supported Platforms__
+  *
+  * -iOS
+  * -Android
+  */
+  @Cordova()
+  exportXFDF(xfdfPath: string): Promise<any> {
+    return;
+  }
+
+ /**
+  * Processes annotations (embed, remove, flatten, or print) and saves the processed document to the given document path.
+  *
+  * @param annotationChange {string} the annotation change. Can be 'flatten', 'remove', 'embed' or 'print'
+  * @param processedDocumentPath {string} description.
+  * @param annotationType {string} The optional string annotationType argument. If omitted, we process 'All' annotations. The annotation type can have one of the following values: None, Undefined, Link, Highlight, StrikeOut, Underline, Squiggly, FreeText, Ink, Square, Circle, Line, Text, Stamp, Caret, RichMedia, Screen, Widget, Sound, FileAttachment, Polygon, PolyLine, Popup, Watermark, TrapNet, 3D, Redact, All.
+  * @return {Promise<any>} callback Success (or result) and error callback function.
+  *
+  * __Supported Platforms__
+  *
+  * -iOS
+  * -Android
+  */
+  @Cordova()
+  processAnnotations(annotationChange: string, processedDocumentPath: string, annotationType: string): Promise<any> {
+    return;
+  }
+
+ /**
+  * Generates a PDF document from HTML string.
+  *
+  * @param html {string} HTML string.
+  * @param fileName {string} File name of the generated PDF.
+  * @param options {string} Options to be considered when converting the HTML string to PDF.
+  * @return {Promise<any>} callback Success (or result) and error callback function.
+  *
+  * __Supported Platforms__
+  *
+  * -iOS
+  */
+  @Cordova()
+  convertPDFFromHTMLString(html: string, fileName: string, options: string): Promise<any> {
+    return;
+  }
+}

--- a/src/@ionic-native/plugins/pspdfkit-cordova/index.ts
+++ b/src/@ionic-native/plugins/pspdfkit-cordova/index.ts
@@ -222,7 +222,7 @@ export class PSPDFKit extends IonicNativePlugin {
  /**
   * Gets several document or view controller options in a single call.
   *
-  * @param names {[any]} array of option names
+  * @param names {any} array of option names
   * @return {Promise<any>} callback Success (or result) and error callback function.
   *
   * __Supported Platforms__
@@ -230,7 +230,7 @@ export class PSPDFKit extends IonicNativePlugin {
   * -iOS
   */
   @Cordova()
-  getOptions(names: [any]): Promise<any> {
+  getOptions(names: any): Promise<any> {
     return;
   }
 


### PR DESCRIPTION
# How to Test in a Newly Created Ionic Project

## 1. Build the PSPDFKit Ionic Native Plugin From This Branch:

1. clone this repo and checkout this branch.
2. `cd` into `Ionic-Native` and run `npm run build`.
3. The newly built plugin can be found in `dist/@ionic-native/pspdfkit-cordova`.

## 2. Integrate Into a Newly Created Ionic Project:

1. Run `ionic start IonicDemo blank --type=angular --id=com.pspdfkit.ionic.example` to create a new Ionic project.
2. `cd` into `IonicDemo` and run `ionic cordova plugin add pspdfkit-cordova` to install the `pspdfkit-cordova` plugin.
3. Add a sample PDF into your `www` directory: `www/pdf/document.pdf`.
4. Open `config.xml` and change the deployment target to iOS 11 or later:

```diff
<platform name="ios">
	<allow-intent href="itms:*" />
	<allow-intent href="itms-apps:*" />
+ 	<allow-navigation href="*" />
+	<preference name="deployment-target" value="11.0" />
</platform>
```

5. Use your CocoaPods Key: `open plugins/pspdfkit-cordova/plugin.xml` and replace `YOUR_COCOAPODS_KEY_GOES_HERE` with your own key. If you’re an existing customer, you can find the CocoaPods and license keys in your [customer portal](https://customers.pspdfkit.com/). Otherwise, if you don’t already have PSPDFKit, [sign up for our 60-day trial](https://pspdfkit.com/try/) and you will receive an email with the instructions to get started.

6. Modify `src/app/app.module.ts` to use PSPDFKit as follows:

```diff
import { NgModule } from '@angular/core';
import { BrowserModule } from '@angular/platform-browser';
import { RouteReuseStrategy } from '@angular/router';

import { IonicModule, IonicRouteStrategy } from '@ionic/angular';
import { SplashScreen } from '@ionic-native/splash-screen/ngx';
import { StatusBar } from '@ionic-native/status-bar/ngx';
+import { PSPDFKit } from '@ionic-native/PSPDFKit-cordova/ngx';

import { AppComponent } from './app.component';
import { AppRoutingModule } from './app-routing.module';

@NgModule({
  declarations: [AppComponent],
  entryComponents: [],
  imports: [BrowserModule, IonicModule.forRoot(), AppRoutingModule],
  providers: [
    StatusBar,
-   SplashScreen	
+   SplashScreen,
+   PSPDFKit,
    { provide: RouteReuseStrategy, useClass: IonicRouteStrategy }
  ],
  bootstrap: [AppComponent]
})
export class AppModule {}
```

7. Modify `src/app/app.component.ts` to use the PSPDFKit plugin to Present a PDF:

```diff
import { Component } from '@angular/core';

import { Platform } from '@ionic/angular';
import { SplashScreen } from '@ionic-native/splash-screen/ngx';
import { StatusBar } from '@ionic-native/status-bar/ngx';
+import { PSPDFKit } from '@ionic-native/PSPDFKit-cordova/ngx';

@Component({
  selector: 'app-root',
  templateUrl: 'app.component.html',
  styleUrls: ['app.component.scss']
})
export class AppComponent {
  constructor(
    private platform: Platform,
    private splashScreen: SplashScreen,
-   private statusBar: StatusBar
+   private statusBar: StatusBar,
+   private pspdfkit: PSPDFKit
  ) {
    this.initializeApp();
  }

  initializeApp() {
    this.platform.ready().then(() => {
      this.statusBar.styleDefault();
      this.splashScreen.hide();
+     this.pspdfkit.setLicenseKey("YOUR LICENSE KEY GOES HERE");
+     this.pspdfkit.present('pdf/document.pdf')
    });
  }
}
```

8. Run `ionic cordova platform add ios` to add the iOS platform.
9. Copy the Ionic Native plugin that you built from the step above into your projects `node_modules/@ionic-native/`. Assuming both repos are forked next to each other, you should run the this command `cp -r ../Ionic-Native/dist/@ionic-native/pspdfkit-cordova /node_modules/@ionic-native/`.
10. Run `ionic cordova prepare ios` to prepare iOS platform.
11. If your application is targeting iOS versions **prior to iOS 12.2** and your application **does not already contain any Swift code**, then you need to make sure Xcode bundles Swift standard libraries with your application distribution. To to so, open your target Build Settings and enable `Always Embed Swift Standard Libraries`:

![always-embed-swift-standard-libraries](https://user-images.githubusercontent.com/7443038/67416381-c6283700-f594-11e9-8014-098f8c067908.png)

12. Run the app: Open `platforms/ios/MyApp.xcworkspace` in Xcode, then build and run, or run `ionic cordova emulate ios` in the Terminal.
