### PR TITLE
fix(ms-adal): add missing "claims" parameter to "acquireTokenAsync" function

### DIFF
--- a/src/@ionic-native/plugins/ms-adal/index.ts
+++ b/src/@ionic-native/plugins/ms-adal/index.ts
@@ -143,7 +143,7 @@ export class AuthenticationContext {
   @CordovaInstance({
     otherPromise: true
   })
-  acquireTokenAsync(resourceUrl: string, clientId: string, redirectUrl: string, userId?: string, extraQueryParameters?: any): Promise<AuthenticationResult> {
+  acquireTokenAsync(resourceUrl: string, clientId: string, redirectUrl: string, userId?: string, extraQueryParameters?: any, claims?: string): Promise<AuthenticationResult> {
     return;
   }
 

--- a/src/@ionic-native/plugins/ms-adal/index.ts
+++ b/src/@ionic-native/plugins/ms-adal/index.ts
@@ -138,6 +138,7 @@ export class AuthenticationContext {
    * @param   {String}  extraQueryParameters
    *                                Extra query parameters (optional)
    *                                Parameters should be escaped before passing to this method (e.g. using 'encodeURI()')
+   * @param   {String}  claims      Claim parameter. Parameter should be used under conditional access scenarios (optional)
    * @returns {Promise} Promise either fulfilled with AuthenticationResult object or rejected with error
    */
   @CordovaInstance({


### PR DESCRIPTION
The `acquireTokenAsync` method has one additional optional parameter called `claims`. Adding support for this parameter in the types.