### PR TITLE
fix(in-app-browser): adds missing customscheme type

### DIFF
--- a/src/@ionic-native/plugins/in-app-browser/index.ts
+++ b/src/@ionic-native/plugins/in-app-browser/index.ts
@@ -123,11 +123,11 @@ export interface InAppBrowserOptions {
   [key: string]: any;
 }
 
-export type InAppBrowserEventType = 'loadstart' | 'loadstop' | 'loaderror' | 'exit' | 'beforeload' | 'message';
+export type InAppBrowserEventType = 'loadstart' | 'loadstop' | 'loaderror' | 'exit' | 'beforeload' | 'message' | 'customscheme';
 
 export interface InAppBrowserEvent extends Event {
   /** the event name */
-  type: InAppBrowserEventType;
+  type: string;
   /** the URL that was loaded. */
   url: string;
   /** the error code, only in the case of loaderror. */
@@ -234,6 +234,28 @@ export class InAppBrowserObject {
    */
   @InstanceCheck()
   on(event: InAppBrowserEventType): Observable<InAppBrowserEvent> {
+    return new Observable<InAppBrowserEvent>(
+      (observer: Observer<InAppBrowserEvent>) => {
+        this._objectInstance.addEventListener(
+          event,
+          observer.next.bind(observer)
+        );
+        return () =>
+          this._objectInstance.removeEventListener(
+            event,
+            observer.next.bind(observer)
+          );
+      }
+    );
+  }
+
+  /**
+   * A method that allows you to listen to events happening in the browser.
+   * @param event {string} Name of the event
+   * @returns {Observable<InAppBrowserEvent>} Returns back an observable that will listen to the event on subscribe, and will stop listening to the event on unsubscribe.
+   */
+  @InstanceCheck()
+  on(event: string): Observable<InAppBrowserEvent> {
     return new Observable<InAppBrowserEvent>(
       (observer: Observer<InAppBrowserEvent>) => {
         this._objectInstance.addEventListener(


### PR DESCRIPTION
This solves the issue of the missing event that is supported by the InAppBrowser plugin: https://github.com/ionic-team/ionic-native/pull/3142#issuecomment-527171665  
This change also adds support for custom events by adding a method overload to support a generic `string`. By adding the overload the IDEs can still provide intellisense for the known events.  
Custom events are very well a thing: https://github.com/apache/cordova-plugin-inappbrowser/issues/514#issuecomment-517362862

The only downside (but `lib.dom.ts` has it, too) is that the `type` property of the `InAppBrowserEvent` needs to be changed to a `string`, too.