### PR TITLE
docs(firebase-x): add /ngx to import in usage example

### DIFF
--- a/src/@ionic-native/plugins/firebase-x/index.ts
+++ b/src/@ionic-native/plugins/firebase-x/index.ts
@@ -79,7 +79,7 @@ export interface IChannelOptions {
  *
  * @usage
  * ```typescript
- * import { FirebaseX } from '@ionic-native/firebase-x';
+ * import { FirebaseX } from '@ionic-native/firebase-x/ngx';
  *
  *
  * constructor(private firebaseX: FirebaseX) { }


### PR DESCRIPTION
**This is only a change to documentation**

**Affected plugin:** cordova-plugin-firebasex

The path used to import FirebaseX in the usage example is wrong, it should end with /ngx