### PR TITLE
feat(iamport-cordova): add iamport-cordova plugin on ionic-native

### DIFF
--- a/src/@ionic-native/plugins/iamport-cordova/index.ts
+++ b/src/@ionic-native/plugins/iamport-cordova/index.ts
@@ -92,28 +92,24 @@ export interface CertificationData {
 export class IamportCordova extends IonicNativePlugin {
 
   /**
-   * This function does something
-   * @param arg1 {string} Some param to configure something
-   * @param arg2 {number} Another param to configure something
+   * This function is to load a webview of a payment gateway to pay for something
+   * @param paymentObject {PaymentObject} Payment data to set the payment webview
    * @return {Promise<any>} Returns a promise that resolves when something happens
+   * A callback function of the payment data is triggered when the webview is closed
    */
   @Cordova()
   payment(paymentObject: PaymentObject): Promise<any> {
-    /**
-     * This function is to load a webview of a payment gateway to pay for something.
-     * The first parameter is payment data to set the payment webview.
-     * A callback function of the payment data is triggered when the webview is closed.
-     */
     return cordova.plugins.IamportCordova.payment(paymentObject);
   }
 
+  /**
+   * This function is to load a webview for identification with carrier type(like Verizon), name and phone number
+   * @param certificationObject {CertificationObject} Certification data to set the certification webview
+   * @return {Promise<any>} Returns a promise that resolves when something happens
+   * A callback function of the certification data is triggered when the webview is closed
+   */
   @Cordova()
   certification(certificationObject: CertificationObject): Promise<any> {
-    /**
-     * This function is to load a webview for identification with carrier type(like Verizon), name and phone number.
-     * The first parameter is certification data to set the certification webview.
-     * * A callback function of the certification data is triggered when the webview is closed.
-     */
     return cordova.plugins.IamportCordova.certification(certificationObject);
   }
 }

--- a/src/@ionic-native/plugins/iamport-cordova/index.ts
+++ b/src/@ionic-native/plugins/iamport-cordova/index.ts
@@ -94,8 +94,7 @@ export class IamportCordova extends IonicNativePlugin {
   /**
    * This function is to load a webview of a payment gateway to pay for something
    * @param paymentObject {PaymentObject} Payment data to set the payment webview
-   * @return {Promise<any>} Returns a promise that resolves when something happens
-   * A callback function of the payment data is triggered when the webview is closed
+   * @return {Promise<any>} A callback function of the payment data is triggered when the webview is closed
    */
   @Cordova()
   payment(paymentObject: PaymentObject): Promise<any> {
@@ -105,8 +104,7 @@ export class IamportCordova extends IonicNativePlugin {
   /**
    * This function is to load a webview for identification with carrier type(like Verizon), name and phone number
    * @param certificationObject {CertificationObject} Certification data to set the certification webview
-   * @return {Promise<any>} Returns a promise that resolves when something happens
-   * A callback function of the certification data is triggered when the webview is closed
+   * @return {Promise<any>} A callback function of the certification data is triggered when the webview is closed
    */
   @Cordova()
   certification(certificationObject: CertificationObject): Promise<any> {

--- a/src/@ionic-native/plugins/iamport-cordova/index.ts
+++ b/src/@ionic-native/plugins/iamport-cordova/index.ts
@@ -1,0 +1,123 @@
+/**
+ * This is a template for new plugin wrappers
+ *
+ * TODO:
+ * - Add/Change information below
+ * - Document usage (importing, executing main functionality)
+ * - Remove any imports that you are not using
+ * - Remove all the comments included in this template, EXCEPT the @Plugin wrapper docs and any other docs you added
+ * - Remove this note
+ *
+ */
+import { Injectable } from '@angular/core';
+import { Plugin, Cordova, CordovaProperty, CordovaInstance, InstanceProperty, IonicNativePlugin } from '@ionic-native/core';
+import { Observable } from 'rxjs';
+
+declare const cordova: Cordova & { plugins: any };
+
+export interface PaymentObject {
+  title?: TitleData;
+  userCode: string;
+  data: PaymentData;
+  callback: any;
+}
+
+export interface CertificationObject {
+  title?: TitleData;
+  userCode: string;
+  data: CertificationData;
+  callback: any;
+}
+
+export interface TitleData {
+  name?: string;
+  color?: string;
+}
+
+export interface PaymentData {
+  pg?: string;
+  pay_method?: string;
+  name: string;
+  merchant_uid?: string;
+  amount: string;
+  buyer_name?: string;
+  buyer_tel?: string;
+  buyer_email?: string;
+  buyer_addr?: string;
+  buyer_postcode?: string;
+  app_scheme: string;
+  custom_data?: any;
+  notice_url?: string;
+  escrow?: boolean;
+  digital?: boolean;
+  display?: {
+    card_quota?: [number];
+  };
+  currency?: string;
+  customer_uid?: string;
+  tax_free?: string;
+  language?: string;
+  vbank_due?: string;
+  biz_num?: string;
+}
+
+export interface CertificationData {
+  company?: string;
+  phone?: string;
+  name?: string;
+  carrier?: string;
+  birth?: string;
+  merchant_uid?: string;
+  min_age?: string;
+  popup?: boolean;
+}
+
+/**
+ * @name Iamport Cordova
+ * @description
+ * This plugin does something
+ *
+ * @usage
+ * ```typescript
+ * import { IamportCordova } from '@ionic-native/iamport-cordova';
+ *
+ *
+ * constructor(private iamportCordova: IamportCordova) { }
+ *
+ * ...
+ *
+ *
+ * this.iamportCordova.functionName('Hello', 123)
+ *   .then((res: any) => console.log(res))
+ *   .catch((error: any) => console.error(error));
+ *
+ * ```
+ */
+@Plugin({
+  pluginName: 'IamportCordova',
+  plugin: 'iamport-cordova', // npm package name, example: cordova-plugin-camera
+  pluginRef: 'cordova.plugins.IamportCordova', // the variable reference to call the plugin, example: navigator.geolocation
+  repo: 'https://github.com/iamport/iamport-cordova', // the github repository URL for the plugin
+  install: '', // OPTIONAL install command, in case the plugin requires variables
+  installVariables: [], // OPTIONAL the plugin requires variables
+  platforms: ['ios', 'android'] // Array of platforms supported, example: ['Android', 'iOS']
+})
+@Injectable()
+export class IamportCordova extends IonicNativePlugin {
+
+  /**
+   * This function does something
+   * @param arg1 {string} Some param to configure something
+   * @param arg2 {number} Another param to configure something
+   * @return {Promise<any>} Returns a promise that resolves when something happens
+   */
+  @Cordova()
+  payment(paymentObject: PaymentObject): Promise<any> {
+    return cordova.plugins.IamportCordova.payment(paymentObject); // We add return; here to avoid any IDE / Compiler errors
+  }
+
+  @Cordova()
+  certification(certificationObject: CertificationObject): Promise<any> {
+    return cordova.plugins.IamportCordova.certification(certificationObject); // We add return; here to avoid any IDE / Compiler errors
+  }
+}

--- a/src/@ionic-native/plugins/iamport-cordova/index.ts
+++ b/src/@ionic-native/plugins/iamport-cordova/index.ts
@@ -103,7 +103,7 @@ export class IamportCordova extends IonicNativePlugin {
      * This function is to load a webview of a payment gateway to pay for something.
      * The first parameter is payment data to set the payment webview.
      * A callback function of the payment data is triggered when the webview is closed.
-    */
+     */
     return cordova.plugins.IamportCordova.payment(paymentObject);
   }
 
@@ -113,7 +113,7 @@ export class IamportCordova extends IonicNativePlugin {
      * This function is to load a webview for identification with carrier type(like Verizon), name and phone number.
      * The first parameter is certification data to set the certification webview.
      * * A callback function of the certification data is triggered when the webview is closed.
-    */
+     */
     return cordova.plugins.IamportCordova.certification(certificationObject);
   }
 }

--- a/src/@ionic-native/plugins/iamport-cordova/index.ts
+++ b/src/@ionic-native/plugins/iamport-cordova/index.ts
@@ -1,64 +1,63 @@
 import { Injectable } from '@angular/core';
-import { Plugin, Cordova, CordovaProperty, CordovaInstance, InstanceProperty, IonicNativePlugin } from '@ionic-native/core';
-import { Observable } from 'rxjs';
+import { Plugin, Cordova, IonicNativePlugin } from '@ionic-native/core';
 
 declare const cordova: Cordova & { plugins: any };
 
 export interface PaymentObject {
-  title?: TitleData;
-  userCode: string;
-  data: PaymentData;
-  callback: any;
+  title?: TitleData;        // webview title data
+  userCode: string;         // user identification code
+  data: PaymentData;        // payment data
+  callback: any;            // callback function after payment
 }
 
 export interface CertificationObject {
-  title?: TitleData;
-  userCode: string;
-  data: CertificationData;
-  callback: any;
+  title?: TitleData;        // webview title data
+  userCode: string;         // user identification code
+  data: CertificationData;  // certification data
+  callback: any;            // callback function after certification
 }
 
 export interface TitleData {
-  name?: string;
-  color?: string;
+  name?: string;            // webview title name
+  color?: string;           // webview title background color
 }
 
 export interface PaymentData {
-  pg?: string;
-  pay_method?: string;
-  name: string;
-  merchant_uid?: string;
-  amount: string;
-  buyer_name?: string;
-  buyer_tel?: string;
-  buyer_email?: string;
-  buyer_addr?: string;
-  buyer_postcode?: string;
-  app_scheme: string;
-  custom_data?: any;
-  notice_url?: string;
-  escrow?: boolean;
-  digital?: boolean;
+  pg?: string;              // payment gateway type
+  pay_method?: string;      // payment method
+  name: string;             // name of order
+  merchant_uid?: string;    // unique merchant id
+  amount: string;           // payment amount
+  buyer_name?: string;      // buyer name
+  buyer_tel?: string;       // buyer contact
+  buyer_email?: string;     // buyer email address
+  buyer_addr?: string;      // buyer address
+  buyer_postcode?: string;  // buyer postcode
+  app_scheme: string;       // custom app url scheme
+  custom_data?: any;        // custom data
+  notice_url?: string;      // notification url
+  escrow?: boolean;         // whether the type of this order is escrow
+  digital?: boolean;        // whether this order is for real products or contents
   display?: {
-    card_quota?: [number];
+    card_quota?: [number];  // credit card installment setting value
   };
-  currency?: string;
-  customer_uid?: string;
-  tax_free?: string;
-  language?: string;
-  vbank_due?: string;
-  biz_num?: string;
+  currency?: string;        // payment currency
+  customer_uid?: string;    // unique customer id for subscription payments
+  tax_free?: string;        // tax amount
+  language?: string;        // language type
+  vbank_due?: string;       // vbank due date
+  biz_num?: string;         // business number
 }
 
 export interface CertificationData {
-  company?: string;
-  phone?: string;
-  name?: string;
-  carrier?: string;
-  birth?: string;
-  merchant_uid?: string;
-  min_age?: string;
-  popup?: boolean;
+  company?: string;         // company name
+  phone?: string;           // cell phone number
+  name?: string;            // name
+  carrier?: string;         // carrier code
+  birth?: string;           // birth date
+  merchant_uid?: string;    // unique merchant id
+  min_age?: string;         // minimum age to allow certification
+  popup?: boolean;          // whether the webview is popup
 }
 
 /**
@@ -100,11 +99,21 @@ export class IamportCordova extends IonicNativePlugin {
    */
   @Cordova()
   payment(paymentObject: PaymentObject): Promise<any> {
-    return cordova.plugins.IamportCordova.payment(paymentObject); // We add return; here to avoid any IDE / Compiler errors
+    /**
+     * This function is to load a webview of a payment gateway to pay for something.
+     * The first parameter is payment data to set the payment webview.
+     * A callback function of the payment data is triggered when the webview is closed.
+    */
+    return cordova.plugins.IamportCordova.payment(paymentObject);
   }
 
   @Cordova()
   certification(certificationObject: CertificationObject): Promise<any> {
-    return cordova.plugins.IamportCordova.certification(certificationObject); // We add return; here to avoid any IDE / Compiler errors
+    /**
+     * This function is to load a webview for identification with carrier type(like Verizon), name and phone number.
+     * The first parameter is certification data to set the certification webview.
+     * * A callback function of the certification data is triggered when the webview is closed.
+    */
+    return cordova.plugins.IamportCordova.certification(certificationObject);
   }
 }

--- a/src/@ionic-native/plugins/iamport-cordova/index.ts
+++ b/src/@ionic-native/plugins/iamport-cordova/index.ts
@@ -1,14 +1,3 @@
-/**
- * This is a template for new plugin wrappers
- *
- * TODO:
- * - Add/Change information below
- * - Document usage (importing, executing main functionality)
- * - Remove any imports that you are not using
- * - Remove all the comments included in this template, EXCEPT the @Plugin wrapper docs and any other docs you added
- * - Remove this note
- *
- */
 import { Injectable } from '@angular/core';
 import { Plugin, Cordova, CordovaProperty, CordovaInstance, InstanceProperty, IonicNativePlugin } from '@ionic-native/core';
 import { Observable } from 'rxjs';
@@ -79,7 +68,7 @@ export interface CertificationData {
  *
  * @usage
  * ```typescript
- * import { IamportCordova } from '@ionic-native/iamport-cordova';
+ * import { IamportCordova } from '@ionic-native/iamport-cordova/ngx';
  *
  *
  * constructor(private iamportCordova: IamportCordova) { }
@@ -95,12 +84,10 @@ export interface CertificationData {
  */
 @Plugin({
   pluginName: 'IamportCordova',
-  plugin: 'iamport-cordova', // npm package name, example: cordova-plugin-camera
-  pluginRef: 'cordova.plugins.IamportCordova', // the variable reference to call the plugin, example: navigator.geolocation
-  repo: 'https://github.com/iamport/iamport-cordova', // the github repository URL for the plugin
-  install: '', // OPTIONAL install command, in case the plugin requires variables
-  installVariables: [], // OPTIONAL the plugin requires variables
-  platforms: ['ios', 'android'] // Array of platforms supported, example: ['Android', 'iOS']
+  plugin: 'iamport-cordova',
+  pluginRef: 'cordova.plugins.IamportCordova',
+  repo: 'https://github.com/iamport/iamport-cordova',
+  platforms: ['ios', 'android']
 })
 @Injectable()
 export class IamportCordova extends IonicNativePlugin {


### PR DESCRIPTION
Hello This is Solee Choi working for a Korean IT Company which is called SIOT.
We offer payment API like Stripes and have been developing some modules for react-native, flutter, capacitor etc.
Now we are working on ionic cordova plugin and trying to add iamport-cordova plugin(https://github.com/iamport/iamport-cordova) on ionic-native to make developers use our plugin on ionic environment.
It would be pleasure for you to allow iamport-cordova plugin.
Thanks!