### PR TITLE
fix(background-geolocation): change syncThreshold type to number

### DIFF
--- a/src/@ionic-native/plugins/background-geolocation/index.ts
+++ b/src/@ionic-native/plugins/background-geolocation/index.ts
@@ -404,7 +404,7 @@ export interface BackgroundGeolocationConfig {
    *
    * @default 100
    */
-  syncThreshold?: string;
+  syncThreshold?: number;
 
   /**
    * Optional HTTP headers sent along in HTTP request.


### PR DESCRIPTION
https://github.com/mauron85/cordova-plugin-background-geolocation#API

The syncThreshold parameter type is Number