### PR TITLE
fix(apple-pay): fix PKPaymentRequest must have valid merchantCapabilities in iOS 12 & 13

### DIFF
--- a/src/@ionic-native/plugins/apple-pay/index.ts
+++ b/src/@ionic-native/plugins/apple-pay/index.ts
@@ -27,6 +27,8 @@ export type ICompleteTransaction = 'Payment status applied.';
 export type IUpdateItemsAndShippingStatus =
   | 'Updated List Info'
   | 'Did you make a payment request?';
+export type IMerchantCapabilities = '3ds' | 'credit' | 'debit' | 'emv';
+export type ISupportedNetworks = 'visa' | 'amex' | 'discover' | 'masterCard';
 
 export interface IPaymentResponse {
   billingNameFirst?: string;
@@ -84,6 +86,8 @@ export interface IOrder extends IOrderItemsAndShippingMethods {
   billingAddressRequirement?: IBillingRequirement | IBillingRequirement[];
   shippingAddressRequirement?: IBillingRequirement | IBillingRequirement[];
   shippingType?: IShippingType;
+  merchantCapabilities?: IMerchantCapabilities | IMerchantCapabilities[];
+  supportedNetworks?: ISupportedNetworks | ISupportedNetworks[];
 }
 
 export interface ISelectedShippingContact {


### PR DESCRIPTION
Fixes the missing merchantCapabilities error in iOS versions 12 & 13.
`
2020-02-15 22:37:26.790765-0500 Tabify[83627:7611347] [General] Payment request is invalid: Error Domain=PKPassKitErrorDomain Code=1 "Invalid in-app payment request" UserInfo={NSLocalizedDescription=Invalid in-app payment request, NSUnderlyingError=0x6000007cc210 {Error Domain=PKPassKitErrorDomain Code=1 "PKPaymentRequest must have valid merchantCapabilities" UserInfo={NSLocalizedDescription=PKPaymentRequest must have valid merchantCapabilities}}}
`

Fix courtesy of https://enappd.com/blog/how-to-integrate-apple-pay-in-ionic-4-apps/21/