### PR TITLE
Incorrect documentation.

### DIFF
--- a/src/@ionic-native/plugins/file/index.ts
+++ b/src/@ionic-native/plugins/file/index.ts
@@ -790,6 +790,7 @@ export class File extends IonicNativePlugin {
 
   /**
    * Get free disk space in Bytes
+   * For Android, it returns KB.
    * @returns {Promise<number>} Returns a promise that resolves with the remaining free disk space in Bytes
    */
   @CordovaCheck()


### PR DESCRIPTION
getFreeDiskSpace returns KB for Android, and not bytes.