### PR TITLE
fix(secure-storage): method is inaccessible when device is not secure

### DIFF
--- a/src/@ionic-native/plugins/secure-storage/index.ts
+++ b/src/@ionic-native/plugins/secure-storage/index.ts
@@ -141,7 +141,7 @@ export class SecureStorage extends IonicNativePlugin {
     return getPromise<SecureStorageObject>((res: Function, rej: Function) => {
       const instance = new (SecureStorage.getPlugin())(
         () => res(new SecureStorageObject(instance)),
-        rej,
+        () => rej(new SecureStorageObject(instance)),
         store
       );
     });


### PR DESCRIPTION
The SecureStorage.create()  method return SecureStorageObject only when the storage is secure, but we need SecureStorageObject to call secureDevice method and redirect the user to the secure device options.

Here a simple fix that riflects the cordova-plugin-storage-echo strategy.

fixes: #2486