### PR TITLE
feat(keychain-touch-id): added userAuthenticationRequired parameter to save method

### DIFF
--- a/src/@ionic-native/plugins/keychain-touch-id/index.ts
+++ b/src/@ionic-native/plugins/keychain-touch-id/index.ts
@@ -50,7 +50,7 @@ export class KeychainTouchId extends IonicNativePlugin {
    * @return {Promise<any>} Returns a promise that resolves when there is a result
    */
   @Cordova()
-  save(key: string, password: string): Promise<any> {
+  save(key: string, password: string, userAuthenticationRequired: boolean ): Promise<any> {
     return;
   }
 

--- a/src/@ionic-native/plugins/keychain-touch-id/index.ts
+++ b/src/@ionic-native/plugins/keychain-touch-id/index.ts
@@ -50,7 +50,7 @@ export class KeychainTouchId extends IonicNativePlugin {
    * @return {Promise<any>} Returns a promise that resolves when there is a result
    */
   @Cordova()
-  save(key: string, password: string, userAuthenticationRequired: boolean ): Promise<any> {
+  save(key: string, password: string, userAuthenticationRequired: boolean): Promise<any> {
     return;
   }
 


### PR DESCRIPTION
Added missing userAuthenticationRequired parameter to save method in definitions file for keychain-touch-id plugin. 

Resolving [this open issue](https://github.com/ionic-team/ionic-native/issues/2749)