### PR TITLE
fix(email-composer): fix error when no mail apps

### DIFF
--- a/src/@ionic-native/plugins/email-composer/index.ts
+++ b/src/@ionic-native/plugins/email-composer/index.ts
@@ -198,7 +198,7 @@ export class EmailComposer extends IonicNativePlugin {
         });
       } else {
         EmailComposer.getPlugin().getClients((apps: string[]) => {
-          resolve(apps.length && apps.length > 0);
+          resolve(apps && apps.length > 0);
         });
       }
     });


### PR DESCRIPTION
When there are no apps installed that can handle "mail", then the "apps" array is returned as `null` from the plugin. This minor change ensures we don't try to call `length` on `null` but maintains the behavior of the original implementation.

The error appears as:
> Unhandled Rejection (TypeError): null is not an object (evaluating 'apps.length').

I didn't see any corresponding unit tests to update. Please let me know if I missed something. This did correct the issue when I changed the file directly in the node_modules for my project.