### PR TITLE
docs(validateExpiryDate): expMonth param month 0 to 11

### DIFF
--- a/src/@ionic-native/plugins/stripe/index.ts
+++ b/src/@ionic-native/plugins/stripe/index.ts
@@ -197,7 +197,7 @@ export class Stripe extends IonicNativePlugin {
 
   /**
    * Validates an expiry date
-   * @param expMonth {string} expiry month
+   * @param expMonth {string} expiry month (0 - 11)
    * @param expYear {string} expiry year
    * @return {Promise<any>} returns a promise that resolves if the date is valid, and rejects if it's invalid
    */


### PR DESCRIPTION
It took me quite a while to realize what is going on with **validateExpiryDate**.

1. The Cordova plugin this ionic native plugin wraps [does not take string, but number](https://github.com/zyra/cordova-plugin-stripe/blob/master/typings/CordovaStripe.d.ts#L51).
2. That this method's documentation does not exist, and can obviously not be looked up in [zyra/cordova-plugin-stripe](https://github.com/zyra/cordova-plugin-stripe), it would be rather nice the code would document it for me at least.
3. And then the big question comes up: What about [the example](https://ionicframework.com/docs/native/stripe#usage) for [StripeCardTokenParams](https://github.com/casaper/ionic-native/blob/master/src/@ionic-native/plugins/stripe/index.ts#L4)? It says `expMonth: 12` and takes number. Why go back to match the lib your wrapping again? And is that not counting January as `0` and `11` ad December? I don't know, and since the wrapper mangles the types forth and back between strype, cordova-stripe plugin and me, I have no at least slightly convenient way to know.

And since the ionic project is super issue reporter unfriendly, I just make a PR...  
I'm generally not really fond with ionic native documentation.  
Since ionic doesn't seem to bother about proper documentation, I take the freedom to not look at your contribution rules as well.... :wink: I hope you guys can forgive me here.

Cheers

