### PR TITLE
fix(firebase-authentication): signInWithVerificationId parameter mismatch

### DIFF
--- a/src/@ionic-native/plugins/firebase-authentication/index.ts
+++ b/src/@ionic-native/plugins/firebase-authentication/index.ts
@@ -109,7 +109,7 @@ export class FirebaseAuthentication extends IonicNativePlugin {
   @Cordova({ sync: true })
   signInWithVerificationId(
     verificationId: string,
-    smsCode: number
+    smsCode: string
   ): Promise<any> {
     return;
   }


### PR DESCRIPTION
When using the function

`this.firebaseAuthentication.signInWithVerificationId(this.verificationID,123456)`

Error is

`by.chemerisuk.cordova.firebase.FirebaseAuthenticationPlugin.signInWithVerificationId argument 2 has type java.lang.String, got java.lang.Integer
`


**and that is because smsCode has to be string instead of number**

package.json
```
    "@ionic-native/firebase-authentication": "^5.23.0",
    "cordova-plugin-firebase-authentication": "^3.1.0",
```

Reference:
https://github.com/ionic-team/ionic-native/issues/2967
https://github.com/chemerisuk/cordova-plugin-firebase-authentication/issues/53
