### PR TITLE
feat(firebase-messaging): add getInstanceId

### DIFF
--- a/src/@ionic-native/plugins/firebase-messaging/index.ts
+++ b/src/@ionic-native/plugins/firebase-messaging/index.ts
@@ -102,6 +102,14 @@ export class FirebaseMessaging extends IonicNativePlugin {
   }
 
   /**
+   * Returns a promise thaf fulfills with the device instance ID
+   */
+  @Cordova({ sync: true })
+  getInstanceId(): Promise<string> {
+    return;
+  }
+
+  /**
    * Returns a promise that fulfills with the current FCM token
    *
    * This method also accepts optional argument type.


### PR DESCRIPTION
Add the `getInstanceId` method, which was added to the cordova plugin in this [commit](https://github.com/chemerisuk/cordova-plugin-firebase-messaging/commit/31c32650a68efd770a4d694b3c41c8ee3db9c856).  Let me know if I need to change anything.  I've tested this locally on iOS successfully.