### PR TITLE
feat(native-storage): add initWithSuiteName

### DIFF
--- a/src/@ionic-native/plugins/native-storage/index.ts
+++ b/src/@ionic-native/plugins/native-storage/index.ts
@@ -37,12 +37,14 @@ import { Cordova, IonicNativePlugin, Plugin } from '@ionic-native/core';
 @Injectable()
 export class NativeStorage extends IonicNativePlugin {
   /**
-   * Initialises shared storage with the suite name when using app groups
+   * Initialises shared storage with the suite name when using app groups in iOS
    * @param reference {string}
-   * @returns {Promise<any>}
+   * @returns {Promise<void>}
    */
-  @Cordova()
-  initWithSuiteName(reference: string): Promise<any> {
+  @Cordova({
+    platforms: ['iOS']
+  })
+  initWithSuiteName(reference: string): Promise<void> {
     return;
   }
 

--- a/src/@ionic-native/plugins/native-storage/index.ts
+++ b/src/@ionic-native/plugins/native-storage/index.ts
@@ -37,6 +37,16 @@ import { Cordova, IonicNativePlugin, Plugin } from '@ionic-native/core';
 @Injectable()
 export class NativeStorage extends IonicNativePlugin {
   /**
+   * Initialises shared storage with the suite name when using app groups
+   * @param reference {string}
+   * @returns {Promise<any>}
+   */
+  @Cordova()
+  initWithSuiteName(reference: string): Promise<any> {
+    return;
+  }
+
+  /**
    * Stores a value
    * @param reference {string}
    * @param value


### PR DESCRIPTION
Required if you want to provide access to storage shared between apps in an app group in iOS.
Relevant section of the documentation for the plugin:
https://github.com/TheCocoaProject/cordova-plugin-nativestorage#usage