### PR TITLE
fix(health): HealthQueryOptionsAggregated bucket optional

### DIFF
--- a/src/@ionic-native/plugins/health/index.ts
+++ b/src/@ionic-native/plugins/health/index.ts
@@ -75,7 +75,7 @@ export interface HealthQueryOptionsAggregated {
    * if specified, aggregation is grouped an array of "buckets" (windows of time),
    * supported values are: 'hour', 'day', 'week', 'month', 'year'.
    */
-  bucket: string;
+  bucket?: string;
 
   /**
    * In Android, it is possible to query for "raw" steps or to select those as filtered by the Google Fit app.


### PR DESCRIPTION
As said in the comment: `if specified, aggregation is grouped an array of "buckets" (windows of time),` the `bucket` field in `HealthQueryOptionsAggregated` should be optional.