### PR TITLE
fix(iamport-cordova): fix data type of card_quota

### DIFF
--- a/src/@ionic-native/plugins/iamport-cordova/index.ts
+++ b/src/@ionic-native/plugins/iamport-cordova/index.ts
@@ -39,7 +39,7 @@ export interface PaymentData {
   escrow?: boolean;         // whether the type of this order is escrow
   digital?: boolean;        // whether this order is for real products or contents
   display?: {
-    card_quota?: [number];  // credit card installment setting value
+    card_quota?: number[],  // credit card installment setting value
   };
   currency?: string;        // payment currency
   customer_uid?: string;    // unique customer id for subscription payments


### PR DESCRIPTION
card_quota property could be undefined, empty array, or numbers of array.
So I changed the data type of card_quota from [number] to number[].

It would be pleasure for ionic-team to merge this pull request.

Thanks for developing an awesome platform!