### PR TITLE
fix(bluetooth-le): change reconnect signature

### DIFF
--- a/src/@ionic-native/plugins/bluetooth-le/index.ts
+++ b/src/@ionic-native/plugins/bluetooth-le/index.ts
@@ -569,10 +569,10 @@ export class BluetoothLE extends IonicNativePlugin {
    * @name reconnect
    * Reconnect to a previously connected Bluetooth device
    * @param {{address: string}} params The address/identifier
-   * @returns {(Observable<{ status: DeviceInfo }>)}
+   * @returns {(Observable<DeviceInfo>)}
    */
   @Cordova({ callbackOrder: 'reverse', observable: true })
-  reconnect(params: { address: string }): Observable<{ status: DeviceInfo }> {
+  reconnect(params: { address: string }): Observable<DeviceInfo> {
     return;
   }
 


### PR DESCRIPTION
change reconnect signature from Observable<{ status: DeviceInfo }> to  Observable<DeviceInfo> fixes #3374