### PR TITLE
feat(appsflyer): added registerUninstall function

### DIFF
--- a/src/@ionic-native/plugins/appsflyer/index.ts
+++ b/src/@ionic-native/plugins/appsflyer/index.ts
@@ -136,6 +136,13 @@ export class Appsflyer extends IonicNativePlugin {
    */
   @Cordova({ sync: true })
   updateServerUninstallToken(token: string): void {}
+  
+    /**
+    * (iOS) Allows to pass APN Tokens that where collected by third party plugins to the AppsFlyer server. Can be used for Uninstall Tracking.
+    * @param {string} token APN Token
+   */
+  @Cordova({ sync: true })
+  registerUninstall(token: string): void {}
 
   /**
    * Get AppsFlyer’s proprietary Device ID. The AppsFlyer Device ID is the main ID used by AppsFlyer in Reports and APIs.

--- a/src/@ionic-native/plugins/appsflyer/index.ts
+++ b/src/@ionic-native/plugins/appsflyer/index.ts
@@ -137,9 +137,9 @@ export class Appsflyer extends IonicNativePlugin {
   @Cordova({ sync: true })
   updateServerUninstallToken(token: string): void {}
   
-    /**
-    * (iOS) Allows to pass APN Tokens that where collected by third party plugins to the AppsFlyer server. Can be used for Uninstall Tracking.
-    * @param {string} token APN Token
+  /**
+   * (iOS) Allows to pass APN Tokens that where collected by third party plugins to the AppsFlyer server. Can be used for Uninstall Tracking.
+   * @param {string} token APN Token
    */
   @Cordova({ sync: true })
   registerUninstall(token: string): void {}

--- a/src/@ionic-native/plugins/appsflyer/index.ts
+++ b/src/@ionic-native/plugins/appsflyer/index.ts
@@ -136,7 +136,7 @@ export class Appsflyer extends IonicNativePlugin {
    */
   @Cordova({ sync: true })
   updateServerUninstallToken(token: string): void {}
-  
+
   /**
    * (iOS) Allows to pass APN Tokens that where collected by third party plugins to the AppsFlyer server. Can be used for Uninstall Tracking.
    * @param {string} token APN Token


### PR DESCRIPTION
According to appsflyer docs, there should be *registerUninstall()* method to allow tracking uninstalls for iOS:

https://github.com/AppsFlyerSDK/appsflyer-cordova-plugin/blob/master/docs/API.md#-registeruninstalltoken-void