### PR TITLE
fix(secure-storage-echo): method is inaccessible when device is not s…

### DIFF
--- a/src/@ionic-native/plugins/secure-storage-echo/index.ts
+++ b/src/@ionic-native/plugins/secure-storage-echo/index.ts
@@ -164,7 +164,7 @@ export class SecureStorageEcho extends IonicNativePlugin {
     return getPromise<SecureStorageEchoObject>((res: Function, rej: Function) => {
         const instance = new (SecureStorageEcho.getPlugin())(
           () => res(new SecureStorageEchoObject(instance)),
-          rej,
+          () => rej(new SecureStorageEchoObject(instance)),
           store,
           options
         );


### PR DESCRIPTION
…ecure #3322
Fix #2486 which was fixed for secure-storage, but not secure-storage-echo.
Despite both native wrappers now referring to https://github.com/mibrito707/cordova-plugin-secure-storage-echo, their APIs are now diverging.
This is a mirror of #3322