### PR TITLE
fix(secure-storage-echo): method is inaccessible when device is not secure #3322

### DIFF
--- a/src/@ionic-native/plugins/secure-storage-echo/index.ts
+++ b/src/@ionic-native/plugins/secure-storage-echo/index.ts
@@ -164,7 +164,7 @@ export class SecureStorageEcho extends IonicNativePlugin {
     return getPromise<SecureStorageEchoObject>((res: Function, rej: Function) => {
         const instance = new (SecureStorageEcho.getPlugin())(
           () => res(new SecureStorageEchoObject(instance)),
-          rej,
+          () => rej(new SecureStorageEchoObject(instance)),
           store,
           options
         );


### PR DESCRIPTION
This is a identical to a change already made to secure-storage.
Let me know if you have any questions or requests.