### PR TITLE
docs(mixpanel): add deprecated on identify

### DIFF
--- a/src/@ionic-native/plugins/mixpanel/index.ts
+++ b/src/@ionic-native/plugins/mixpanel/index.ts
@@ -188,6 +188,7 @@ export class MixpanelPeople extends IonicNativePlugin {
    *
    * @param distinctId {string}
    * @return {Promise<any>}
+   * @deprecated since 2016-11-21 - Use Mixpanel.identify instead.
    */
   @Cordova()
   identify(distinctId: string): Promise<any> {


### PR DESCRIPTION
The plugin method of MixpanelPeople.identify() fails on iOS as it is not supported anymore causing an uncaught exception. The plugin expects 2 arguments while the identify method only provides 1. 

See the the plugin repo for more info: [cordova-mixpanel-plugin](https://github.com/samzilverberg/cordova-mixpanel-plugin/blob/master/www/mixpanel.js )

changes:
1. Added @deprecated to MixpanelPeople.identify()