### PR TITLE
[Docs] Add premier and Capacitor incompatible metadata to plugins

### DIFF
--- a/scripts/docs-json/index.ts
+++ b/scripts/docs-json/index.ts
@@ -15,6 +15,8 @@ interface Plugin {
   cordovaPlugin: {
     name: string;
   };
+  premierSlug: string;
+  capacitorIncompatible: boolean;
 }
 
 const rootDir = resolve(__dirname, '../..');
@@ -55,6 +57,9 @@ function processPlugin(pluginModule): Plugin {
   const displayName = getTag(pluginClass, 'name');
   const usage = getTag(pluginClass, 'usage');
   const description = getTag(pluginClass, 'description');
+  const premierSlug = getTag(pluginClass, 'premier');
+  const capIncompat = getTag(pluginClass, 'capacitorincompatible');
+  const capacitorIncompatible = capIncompat ? true : undefined;
   return {
     packageName,
     displayName,
@@ -66,6 +71,8 @@ function processPlugin(pluginModule): Plugin {
     cordovaPlugin: {
       name: decorator.plugin,
     },
+    premierSlug,
+    capacitorIncompatible,
   };
 }
 

--- a/src/@ionic-native/plugins/admob-pro/index.ts
+++ b/src/@ionic-native/plugins/admob-pro/index.ts
@@ -100,6 +100,7 @@ export interface AdExtras {
 /**
  * @paid
  * @name AdMob Pro
+ * @capacitorincompatible true
  * @description
  * Plugin for Google Ads, including AdMob / DFP (DoubleClick for publisher) and mediations to other Ad networks.
  *

--- a/src/@ionic-native/plugins/android-permissions/index.ts
+++ b/src/@ionic-native/plugins/android-permissions/index.ts
@@ -3,6 +3,7 @@ import { Cordova, IonicNativePlugin, Plugin } from '@ionic-native/core';
 
 /**
  * @name Android Permissions
+ * @premier android-permissions
  * @description
  * This plugin is designed to support Android new permissions checking mechanism.
  *

--- a/src/@ionic-native/plugins/app-rate/index.ts
+++ b/src/@ionic-native/plugins/app-rate/index.ts
@@ -133,6 +133,7 @@ export interface AppUrls {
 
 /**
  * @name App Rate
+ * @premier app-rate
  * @description
  * The AppRate plugin makes it easy to prompt the user to rate your app, either now, later, or never.
  *

--- a/src/@ionic-native/plugins/app-version/index.ts
+++ b/src/@ionic-native/plugins/app-version/index.ts
@@ -3,6 +3,7 @@ import { Cordova, IonicNativePlugin, Plugin } from '@ionic-native/core';
 
 /**
  * @name App Version
+ * @premier app-version
  * @description
  * Reads the version of your app from the target build settings.
  *

--- a/src/@ionic-native/plugins/apple-wallet/index.ts
+++ b/src/@ionic-native/plugins/apple-wallet/index.ts
@@ -33,6 +33,7 @@ export interface WatchExistData {
 
 /**
  * @name Apple Wallet
+ * @premier apple-payment-pass
  * @description
  * A Cordova plugin that enables users from Add Payment Cards to their Apple Wallet.
  *

--- a/src/@ionic-native/plugins/badge/index.ts
+++ b/src/@ionic-native/plugins/badge/index.ts
@@ -3,6 +3,7 @@ import { Cordova, IonicNativePlugin, Plugin } from '@ionic-native/core';
 
 /**
  * @name Badge
+ * @premier badge
  * @description
  * The essential purpose of badge numbers is to enable an application to inform its users that it has something for them — for example, unread messages — when the application isn’t running in the foreground.
  *

--- a/src/@ionic-native/plugins/braintree/index.ts
+++ b/src/@ionic-native/plugins/braintree/index.ts
@@ -136,6 +136,7 @@ export interface PaymentUIResult {
 
 /**
  * @name Braintree
+ * @capacitorincompatible true
  * @description
  * This plugin enables the use of the Braintree Drop-In Payments UI in your Ionic applications on Android and iOS, using the native Drop-In UI for each platform (not the Javascript SDK).
  *

--- a/src/@ionic-native/plugins/calendar/index.ts
+++ b/src/@ionic-native/plugins/calendar/index.ts
@@ -58,6 +58,7 @@ export interface NameOrOptions {
 
 /**
  * @name Calendar
+ * @premier calendar
  * @description
  * This plugin allows you to add events to the Calendar of the mobile device.
  *

--- a/src/@ionic-native/plugins/camera/index.ts
+++ b/src/@ionic-native/plugins/camera/index.ts
@@ -123,6 +123,7 @@ export enum Direction {
 
 /**
  * @name Camera
+ * @premier camera
  * @description
  * Take a photo or capture video.
  *

--- a/src/@ionic-native/plugins/clipboard/index.ts
+++ b/src/@ionic-native/plugins/clipboard/index.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@angular/core';
 import { Cordova, IonicNativePlugin, Plugin } from '@ionic-native/core';
 /**
  * @name Clipboard
+ * @premier clipboard
  * @description
  * Clipboard management plugin for Cordova that supports iOS, Android, and Windows Phone 8.
  *

--- a/src/@ionic-native/plugins/contacts/index.ts
+++ b/src/@ionic-native/plugins/contacts/index.ts
@@ -300,6 +300,7 @@ export class ContactFindOptions implements IContactFindOptions {
 
 /**
  * @name Contacts
+ * @premier contacts
  * @description
  * Access and manage Contacts on the device.
  *

--- a/src/@ionic-native/plugins/deeplinks/index.ts
+++ b/src/@ionic-native/plugins/deeplinks/index.ts
@@ -30,6 +30,7 @@ export interface DeeplinkOptions {
 
 /**
  * @name Deeplinks
+ * @premier deeplinks
  * @description This plugin handles deeplinks on iOS and Android for both custom URL scheme links
  * and Universal App Links.
  *

--- a/src/@ionic-native/plugins/device-feedback/index.ts
+++ b/src/@ionic-native/plugins/device-feedback/index.ts
@@ -11,6 +11,7 @@ export interface DeviceFeedbackStatus {
 
 /**
  * @name Device Feedback
+ * @premier vibration
  * @description
  *
  * Plugin that lets you provide haptic or acoustic feedback on Android devices.

--- a/src/@ionic-native/plugins/device/index.ts
+++ b/src/@ionic-native/plugins/device/index.ts
@@ -5,6 +5,7 @@ declare const window: any;
 
 /**
  * @name Device
+ * @premier device
  * @description
  * Access information about the underlying device and platform.
  *

--- a/src/@ionic-native/plugins/dialogs/index.ts
+++ b/src/@ionic-native/plugins/dialogs/index.ts
@@ -15,6 +15,7 @@ export interface DialogsPromptCallback {
 
 /**
  * @name Dialogs
+ * @premier dialogs
  * @description
  * This plugin gives you ability to access and customize the device native dialogs.
  *

--- a/src/@ionic-native/plugins/email-composer/index.ts
+++ b/src/@ionic-native/plugins/email-composer/index.ts
@@ -50,6 +50,7 @@ export interface EmailComposerOptions {
 
 /**
  * @name Email Composer
+ * @premier email-composer
  * @description
  *
  * Requires Cordova plugin: cordova-plugin-email-composer. For more info, please see the [Email Composer plugin docs](https://github.com/hypery2k/cordova-email-plugin).

--- a/src/@ionic-native/plugins/fcm/index.ts
+++ b/src/@ionic-native/plugins/fcm/index.ts
@@ -18,6 +18,7 @@ export interface NotificationData {
 
 /**
  * @name FCM
+ * @capacitorincompatible true
  * @description
  * Provides basic functionality for Firebase Cloud Messaging
  *

--- a/src/@ionic-native/plugins/file-path/index.ts
+++ b/src/@ionic-native/plugins/file-path/index.ts
@@ -5,6 +5,7 @@ declare const window: any;
 
 /**
  * @name File Path
+ * @premier filesystem
  * @description
  *
  * This plugin allows you to resolve the native filesystem path for Android content URIs and is based on code in the aFileChooser library.

--- a/src/@ionic-native/plugins/file/index.ts
+++ b/src/@ionic-native/plugins/file/index.ts
@@ -636,6 +636,7 @@ declare const window: Window;
 
 /**
  * @name File
+ * @premier filesystem
  * @description
  * This plugin implements a File API allowing read/write access to files residing on the device.
  *

--- a/src/@ionic-native/plugins/firebase/index.ts
+++ b/src/@ionic-native/plugins/firebase/index.ts
@@ -4,6 +4,7 @@ import { Observable } from 'rxjs';
 
 /**
  * @name Firebase
+ * @capacitorincompatible true
  * @description
  * This plugin brings push notifications, analytics, event tracking, crash reporting and more from Google Firebase to your Cordova project! Android and iOS supported (including iOS 10).
  *

--- a/src/@ionic-native/plugins/geolocation/index.ts
+++ b/src/@ionic-native/plugins/geolocation/index.ts
@@ -106,6 +106,7 @@ export interface GeolocationOptions {
 
 /**
  * @name Geolocation
+ * @premier geolocation
  * @description
  * This plugin provides information about the device's location, such as latitude and longitude. Common sources of location information include Global Positioning System (GPS) and location inferred from network signals such as IP address, RFID, WiFi and Bluetooth MAC addresses, and GSM/CDMA cell IDs.
  *

--- a/src/@ionic-native/plugins/globalization/index.ts
+++ b/src/@ionic-native/plugins/globalization/index.ts
@@ -8,6 +8,7 @@ export interface GlobalizationOptions {
 
 /**
  * @name Globalization
+ * @premier globalization
  * @description
  * This plugin obtains information and performs operations specific to the user's locale, language, and timezone.
  *

--- a/src/@ionic-native/plugins/in-app-browser/index.ts
+++ b/src/@ionic-native/plugins/in-app-browser/index.ts
@@ -252,6 +252,7 @@ export class InAppBrowserObject {
 
 /**
  * @name In App Browser
+ * @premier inappbrowser
  * @description Launches in app Browser
  * @usage
  * ```typescript

--- a/src/@ionic-native/plugins/ionic-webview/index.ts
+++ b/src/@ionic-native/plugins/ionic-webview/index.ts
@@ -3,6 +3,7 @@ import { CordovaProperty, IonicNativePlugin, Plugin } from '@ionic-native/core';
 
 /**
  * @name Ionic Webview
+ * @capacitorincompatible true
  * @description
  * Access Web View utilities.
  *

--- a/src/@ionic-native/plugins/keyboard/index.ts
+++ b/src/@ionic-native/plugins/keyboard/index.ts
@@ -16,6 +16,8 @@ export enum KeyboardResizeMode {
 
 /**
  * @name Keyboard
+ * @premier keyboard
+ * @capacitorincompatible true
  * @description
  * Keyboard plugin for Cordova.
  *

--- a/src/@ionic-native/plugins/media-capture/index.ts
+++ b/src/@ionic-native/plugins/media-capture/index.ts
@@ -114,6 +114,7 @@ export interface ConfigurationData {
 
 /**
  * @name Media Capture
+ * @premier media-capture
  * @description
  * This plugin provides access to the device's audio, image, and video capture capabilities.
  *

--- a/src/@ionic-native/plugins/media/index.ts
+++ b/src/@ionic-native/plugins/media/index.ts
@@ -179,6 +179,7 @@ export type MediaErrorCallback = (error: MediaError) => void;
 
 /**
  * @name Media
+ * @premier media
  * @description
  * This plugin provides the ability to record and play back audio files on a device.
  *

--- a/src/@ionic-native/plugins/music-controls/index.ts
+++ b/src/@ionic-native/plugins/music-controls/index.ts
@@ -30,6 +30,7 @@ export interface MusicControlsOptions {
 
 /**
  * @name Music Controls
+ * @capacitorincompatible true
  * @description
  * Music controls for Cordova applications.
  * Display a 'media' notification with play/pause, previous, next buttons, allowing the user to control the play.

--- a/src/@ionic-native/plugins/native-storage/index.ts
+++ b/src/@ionic-native/plugins/native-storage/index.ts
@@ -3,6 +3,7 @@ import { Cordova, IonicNativePlugin, Plugin } from '@ionic-native/core';
 
 /**
  * @name Native Storage
+ * @premier nativestorage
  * @description Native storage of variables in Android and iOS
  *
  * @usage

--- a/src/@ionic-native/plugins/network/index.ts
+++ b/src/@ionic-native/plugins/network/index.ts
@@ -17,6 +17,7 @@ export enum Connection {
 
 /**
  * @name Network
+ * @premier network-information
  * @description
  * Requires Cordova plugin: cordova-plugin-network-information. For more info, please see the [Network plugin docs](https://github.com/apache/cordova-plugin-network-information).
  *

--- a/src/@ionic-native/plugins/qr-scanner/index.ts
+++ b/src/@ionic-native/plugins/qr-scanner/index.ts
@@ -60,6 +60,7 @@ export interface QRScannerStatus {
 
 /**
  * @name QR Scanner
+ * @capacitorincompatible true
  * @description
  * A fast, energy efficient, highly-configurable QR code scanner for Cordova apps.
  *

--- a/src/@ionic-native/plugins/screen-orientation/index.ts
+++ b/src/@ionic-native/plugins/screen-orientation/index.ts
@@ -4,6 +4,7 @@ import { Observable } from 'rxjs';
 
 /**
  * @name Screen Orientation
+ * @premier screen-orientation
  * @description
  * Cordova plugin to set/lock the screen orientation in a common way.
  *

--- a/src/@ionic-native/plugins/social-sharing/index.ts
+++ b/src/@ionic-native/plugins/social-sharing/index.ts
@@ -3,6 +3,7 @@ import { Cordova, IonicNativePlugin, Plugin } from '@ionic-native/core';
 
 /**
  * @name Social Sharing
+ * @premier social-sharing
  * @description
  * Share text, files, images, and links via social networks, sms, and email.
  *

--- a/src/@ionic-native/plugins/splash-screen/index.ts
+++ b/src/@ionic-native/plugins/splash-screen/index.ts
@@ -3,6 +3,8 @@ import { Cordova, IonicNativePlugin, Plugin } from '@ionic-native/core';
 
 /**
  * @name Splash Screen
+ * @premier splashscreen
+ * @capacitorincompatible true
  * @description This plugin displays and hides a splash screen during application launch. The methods below allows showing and hiding the splashscreen after the app has loaded.
  * @usage
  * ```typescript

--- a/src/@ionic-native/plugins/status-bar/index.ts
+++ b/src/@ionic-native/plugins/status-bar/index.ts
@@ -3,6 +3,8 @@ import { Cordova, CordovaProperty, IonicNativePlugin, Plugin } from '@ionic-nati
 
 /**
  * @name Status Bar
+ * @premier statusbar
+ * @capacitorincompatible true
  * @description
  * Manage the appearance of the native status bar.
  *

--- a/src/@ionic-native/plugins/vibration/index.ts
+++ b/src/@ionic-native/plugins/vibration/index.ts
@@ -3,6 +3,7 @@ import { Cordova, IonicNativePlugin, Plugin } from '@ionic-native/core';
 
 /**
  * @name Vibration
+ * @premier vibration
  * @description Vibrates the device
  * @usage
  * ```typescript


### PR DESCRIPTION
Addresses [this issue](https://github.com/ionic-team/ionic-docs/issues/1231). Full background there.

Last year, two new JSON attributes were added to ionic-docs' native.json file (capacitorIncompatible and premierSlug) that do not exist in Ionic Native plugin metadata itself. Both repos became out of sync and following the "official" update process would cause those attributes to disappear, but they need to exist.

As a result, it's been challenging to update the Ionic docs with any changes to community plugins. This PR fixes that, and moving forward we'll be sure to make changes here first, so that both repos don't get out of sync again.

I'm not very familiar with the Ionic Native build process - I don't _think_ these changes break anything, but appreciate a review from someone who knows more.