### PR TITLE
fix(geolocation): #3303 geolocation watchPosition return type

### DIFF
--- a/src/@ionic-native/plugins/geolocation/index.ts
+++ b/src/@ionic-native/plugins/geolocation/index.ts
@@ -194,8 +194,8 @@ export class Geolocation extends IonicNativePlugin {
    * @param {GeolocationOptions} options  The [geolocation options](https://developer.mozilla.org/en-US/docs/Web/API/PositionOptions).
    * @returns {Observable<Geoposition>} Returns an Observable that notifies with the [position](https://developer.mozilla.org/en-US/docs/Web/API/Position) of the device, or errors.
    */
-  watchPosition(options?: GeolocationOptions): Observable<Geoposition> {
-    return new Observable<Geoposition>((observer: any) => {
+  watchPosition(options?: GeolocationOptions): Observable<Geoposition | PositionError> {
+    return new Observable<Geoposition | PositionError>((observer: any) => {
       const watchId = navigator.geolocation.watchPosition(
         observer.next.bind(observer),
         observer.next.bind(observer),

--- a/src/@ionic-native/plugins/geolocation/index.ts
+++ b/src/@ionic-native/plugins/geolocation/index.ts
@@ -192,7 +192,7 @@ export class Geolocation extends IonicNativePlugin {
    * ```
    *
    * @param {GeolocationOptions} options  The [geolocation options](https://developer.mozilla.org/en-US/docs/Web/API/PositionOptions).
-   * @returns {Observable<Geoposition>} Returns an Observable that notifies with the [position](https://developer.mozilla.org/en-US/docs/Web/API/Position) of the device, or errors.
+   * @returns {Observable<Geoposition | PositionError>} Returns an Observable that notifies with the [position](https://developer.mozilla.org/en-US/docs/Web/API/Position) of the device, or errors.
    */
   watchPosition(options?: GeolocationOptions): Observable<Geoposition | PositionError> {
     return new Observable<Geoposition | PositionError>((observer: any) => {


### PR DESCRIPTION
The return type of `watchPosition` is wrong. `Geoposition` **and** `PositionError` will pass to the Observable. Therefore the return type has to be changed to reflect this behavior.  

### Fixes
#3303 