### PR TITLE
feat(onesignal): add missing callback params

### DIFF
--- a/src/@ionic-native/plugins/onesignal/index.ts
+++ b/src/@ionic-native/plugins/onesignal/index.ts
@@ -771,14 +771,32 @@ export class OneSignal extends IonicNativePlugin {
   /**
    * Allows you to use your own system's user ID's to send push notifications to your users.
    * To tie a user to a given user ID, you can use this method.
+   *
+   * The callback result JSONObject param will contain push and email success statuses:
+   * {
+   *   push: { success: boolean },
+   *   email?: { success: boolean }
+   * }
+   * 'Push' can be expected in almost every situation with a success status, but
+   * as a pre-caution its good to verify if it exists.
    * @param {string} externalId
+   * @param {Function} callback
    */
   @Cordova()
-  setExternalUserId(externalId: string): void {}
+  setExternalUserId(externalId: string, callback?: Function): void {}
 
   /**
    * Removes whatever was set as the current user's external user ID.
+   *
+   * The callback result JSONObject param will contain push and email success statuses:
+   * {
+   *   push: { success: boolean },
+   *   email?: { success: boolean }
+   * }
+   * 'Push' can be expected in almost every situation with a success status, but
+   * as a pre-caution its good to verify if it exists.
+   * @param {Function} callback
    */
   @Cordova()
-  removeExternalUserId(): void {}
+  removeExternalUserId(callback?: Function): void {}
 }


### PR DESCRIPTION
Fix issue #3477

I didn't write the callback function type as none of the SDKs seems to do (they are just generic JSONObject types, like seem here on [Android SDK](https://github.com/OneSignal/OneSignal-Android-SDK/blob/68f6ade7ac30e8d3038213957134627940079cb4/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java#L204)). On the [SDK Reference](https://documentation.onesignal.com/docs/sdk-reference#setexternaluserid-method) entry example they hint at what the result content might be, so I add this as a comment above the method.