### PR TITLE
refactor(firebase-dynamic-links): removed interface that doesn't apply to the api

### DIFF
--- a/src/@ionic-native/plugins/firebase-dynamic-links/index.ts
+++ b/src/@ionic-native/plugins/firebase-dynamic-links/index.ts
@@ -7,10 +7,6 @@ export interface IDynamicLink {
   deepLink: string;
 }
 
-export interface ICreatedDynamicLink {
-  url: string;
-}
-
 export interface ILinkOptions {
   domainUriPrefix?: string;
   link?: string;
@@ -116,36 +112,36 @@ export class FirebaseDynamicLinks extends IonicNativePlugin {
   /**
    * Creates a Dynamic Link from the parameters. Returns a promise fulfilled with the new dynamic link url.
    * @param {ILinkOptions} opt [Dynamic Link Parameters](https://github.com/chemerisuk/cordova-plugin-firebase-dynamiclinks#dynamic-link-parameters)
-   * @return {Promise<ICreatedDynamicLink>} Returns a promise with the url
+   * @return {Promise<string>} Returns a promise with the url
    */
   @Cordova({
     otherPromise: true,
   })
-  createDynamicLink(opts: ILinkOptions): Promise<ICreatedDynamicLink> {
+  createDynamicLink(opts: ILinkOptions): Promise<string> {
     return;
   }
 
   /**
    * Creates a shortened Dynamic Link from the parameters. Shorten the path to a string that is only as long as needed to be unique, with a minimum length of 4 characters. Use this method if sensitive information would not be exposed if a short Dynamic Link URL were guessed.
    * @param {ILinkOptions} opt [Dynamic Link Parameters](https://github.com/chemerisuk/cordova-plugin-firebase-dynamiclinks#dynamic-link-parameters)
-   * @return {Promise<ICreatedDynamicLink>} Returns a promise with the url
+   * @return {Promise<string>} Returns a promise with the url
    */
   @Cordova({
     otherPromise: true,
   })
-  createShortDynamicLink(opts: ILinkOptions): Promise<ICreatedDynamicLink> {
+  createShortDynamicLink(opts: ILinkOptions): Promise<string> {
     return;
   }
 
   /**
    * Creates a Dynamic Link from the parameters. Shorten the path to an unguessable string. Such strings are created by base62-encoding randomly generated 96-bit numbers, and consist of 17 alphanumeric characters. Use unguessable strings to prevent your Dynamic Links from being crawled, which can potentially expose sensitive information.
    * @param {ILinkOptions} opt [Dynamic Link Parameters](https://github.com/chemerisuk/cordova-plugin-firebase-dynamiclinks#dynamic-link-parameters)
-   * @return {Promise<ICreatedDynamicLink>} Returns a promise with the url
+   * @return {Promise<string>} Returns a promise with the url
    */
   @Cordova({
     otherPromise: true,
   })
-  createUnguessableDynamicLink(opts: ILinkOptions): Promise<ICreatedDynamicLink> {
+  createUnguessableDynamicLink(opts: ILinkOptions): Promise<string> {
     return;
   }
 }


### PR DESCRIPTION
The interface `ICreatedDynamicLink` isn't the correct typing for the cordova-plugin (see https://github.com/chemerisuk/cordova-plugin-firebase-dynamiclinks)
I also currently need the following ugly conversion, because the real plugin returns a string instead of an interface.

```typescript
this.firebaseDynamicLinks
          .createDynamicLink({
            link: "https://XXX",
          })
          .then((link) => {
            window.location.href = link as unknown as string ;
          });
```