### PR TITLE
fix(ble) #3506 : leave a chance to client to reorder sequences 

### DIFF
--- a/src/@ionic-native/plugins/ble/index.ts
+++ b/src/@ionic-native/plugins/ble/index.ts
@@ -455,6 +455,8 @@ export class BLE extends IonicNativePlugin {
    * @param {string} serviceUUID  UUID of the BLE service
    * @param {string} characteristicUUID  UUID of the BLE characteristic
    * @return {Observable<any>} Returns an Observable that notifies of characteristic changes.
+   * The observer emit an array with data at index 0 and sequence order at index 1.
+   * The sequence order is always undefined on iOS. On android it leave the client to check the sequence order and reorder if needed
    */
   @Cordova({
     observable: true,

--- a/src/@ionic-native/plugins/ble/index.ts
+++ b/src/@ionic-native/plugins/ble/index.ts
@@ -458,6 +458,7 @@ export class BLE extends IonicNativePlugin {
    */
   @Cordova({
     observable: true,
+    destruct: true,
     clearFunction: 'stopNotification',
     clearWithArgs: true,
   })


### PR DESCRIPTION
To resume :

- Cordova doesn't guarantee callback ordering relative to when they are queued. See [this analyze](https://github.com/don/cordova-plugin-ble-central/issues/625) of @timburke. Thanks to him.
- cordova-plugin-ble-central has fixed this by adding a second parameter to the callback to leave the client checking and reordering the sequences order. This fix has been included in version 1.2.4. [Here](https://github.com/don/cordova-plugin-ble-central/pull/656) the PR
- The second parameter of plugin callback was not accessible from IONIC wrapper used to convert callback to observable
- I changed the option of wrapper by adding the destruct option. Now the value returned by subscription on the observable is an array with at index 0 the data value and at index 1 the sequence order. This is a breaking change
