### PR TITLE
feat(firebase-x): Add missing function reloadCurrentUser()

### DIFF
--- a/src/@ionic-native/plugins/firebase-x/index.ts
+++ b/src/@ionic-native/plugins/firebase-x/index.ts
@@ -169,13 +169,22 @@ export class FirebaseX extends IonicNativePlugin {
   getId(): Promise<null | string> {
     return;
   }
-
+  
   /**
    * Get the current FCM user.
    * @return {Promise<FirebaseUser | string>}
    */
   @Cordova()
   getCurrentUser(): Promise<FirebaseUser | string> {
+    return;
+  }
+  
+  /**
+   * Reload the current FCM user.
+   * @return {Promise<FirebaseUser | string>}
+   */
+  @Cordova()
+  reloadCurrentUser(): Promise<FirebaseUser | string> {
     return;
   }
 


### PR DESCRIPTION
Added the missing function reloadCurrentUser() for cordova-plugin-firebasex. This is identical to the already implemented function getCurrentUser(), but instead of loading the user from local memory, it reloads it from Firebase.

https://github.com/dpa99c/cordova-plugin-firebasex#reloadcurrentuser