### PR TITLE
fix(http): add missing type to serialiser property

### DIFF
--- a/src/@ionic-native/plugins/http/index.ts
+++ b/src/@ionic-native/plugins/http/index.ts
@@ -352,7 +352,7 @@ export class HTTP extends IonicNativePlugin {
       method: 'get' | 'post' | 'put' | 'patch' | 'head' | 'delete' | 'options' | 'upload' | 'download';
       data?: { [index: string]: any };
       params?: { [index: string]: string | number };
-      serializer?: 'json' | 'urlencoded' | 'utf8' | 'multipart';
+      serializer?: 'json' | 'urlencoded' | 'utf8' | 'multipart' | 'raw';
       timeout?: number;
       headers?: { [index: string]: string };
       filePath?: string | string[];


### PR DESCRIPTION
cordova http API has a 'raw' serializer, and in it is referenced several times in this file. It is even possible to set the serializer using `setDataSerializer('raw')`

This serializer is required for sending binary data.