### PR TITLE
fix(diagnostics): locationAccuracyAuthorization Property missing in build

### DIFF
--- a/src/@ionic-native/plugins/diagnostic/index.ts
+++ b/src/@ionic-native/plugins/diagnostic/index.ts
@@ -94,8 +94,8 @@ export class Diagnostic extends IonicNativePlugin {
    * Location accuracy authorization
    */
   locationAccuracyAuthorization: {
-    FULL: 'full';
-    REDUCED: 'reduced';
+    FULL: 'full',
+    REDUCED: 'reduced',
   };
 
   permissionGroups = {


### PR DESCRIPTION
Just noticed, that the **locationAccuracyAuthorization** Property from my last PR (#3490) is missing in final build's `index.js`. The only difference to the other Properties was the comma/semicolon, so i changed this. Hope it's correct now?

Sorry for the issue in the last PR...