### PR TITLE
fix(music-controls): update associated cordova plugin

### DIFF
--- a/src/@ionic-native/plugins/music-controls/index.ts
+++ b/src/@ionic-native/plugins/music-controls/index.ts
@@ -148,9 +148,9 @@ export interface MusicControlsOptions {
  */
 @Plugin({
   pluginName: 'MusicControls',
-  plugin: 'cordova-plugin-music-controls',
+  plugin: 'cordova-plugin-music-controls2',
   pluginRef: 'MusicControls',
-  repo: 'https://github.com/homerours/cordova-music-controls-plugin',
+  repo: 'https://github.com/ghenry22/cordova-plugin-music-controls2',
   platforms: ['Android', 'iOS', 'Windows'],
 })
 @Injectable()


### PR DESCRIPTION
This path is necessary to use plugin in Capacitor see:
https://capacitorjs.com/docs/cordova/known-incompatible-plugins

The original project message in github.com:
No longer maintained.
Gavin Henry (ghenry22) has been maintaining a fork that should be updated and working better than this one. Please use his fork.

Is recomended update Ionic Documentation:
https://ionicframework.com/docs/native/music-controls
