### PR TITLE
fix(in-App-purchase2) Correct type definition for date fields

### DIFF
--- a/src/@ionic-native/plugins/in-app-purchase-2/index.ts
+++ b/src/@ionic-native/plugins/in-app-purchase-2/index.ts
@@ -55,9 +55,9 @@ export interface IAPProduct {
 
   downloaded?: boolean;
 
-  lastRenewalDate?: string;
+  lastRenewalDate?: Date;
 
-  expiryDate?: string;
+  expiryDate?: Date;
 
   introPrice?: string;
 


### PR DESCRIPTION
IAPProduct.expiryDate and renewalDate is defined as string but must be defined as Date

lastRenewalDate?: Date;
expiryDate?: Date;

Other information:
https://github.com/j3k0/cordova-plugin-purchase/blob/master/doc/api.md#storeproduct-public-attributes

it's the fix for #3516