### PR TITLE
fix(in-app-purchase-2): change in-app-purchase-2 plugin id

### DIFF
--- a/src/@ionic-native/plugins/in-app-purchase-2/index.ts
+++ b/src/@ionic-native/plugins/in-app-purchase-2/index.ts
@@ -541,11 +541,11 @@ export class IAPError {
  */
 @Plugin({
   pluginName: 'InAppPurchase2',
-  plugin: 'cc.fovea.cordova.purchase',
+  plugin: 'cordova-plugin-purchase',
   pluginRef: 'store',
   repo: 'https://github.com/j3k0/cordova-plugin-purchase',
   platforms: ['iOS', 'Android', 'Windows'],
-  install: 'ionic cordova plugin add cc.fovea.cordova.purchase --variable BILLING_KEY="<ANDROID_BILLING_KEY>"',
+  install: 'ionic cordova plugin add cordova-plugin-purchase --variable BILLING_KEY="<ANDROID_BILLING_KEY>"',
 })
 @Injectable()
 export class InAppPurchase2 extends IonicNativePlugin {


### PR DESCRIPTION
it was renamed from cc.fovea.cordova.purchase to cordova-plugin-purchase

https://github.com/j3k0/cordova-plugin-purchase/commit/14305f35c0d17aaed27119164ed3a5c7922b43ab

closes https://github.com/ionic-team/ionic-native/issues/3554