### PR TITLE
feat(core): add `methodName` to Cordova Decorator

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -168,6 +168,7 @@ A decorator to wrap the main plugin class, and any other classes that will use `
 Checks if the plugin and the method are available before executing. By default, the decorator will wrap the callbacks of the function and return a Promise. This decorator takes the following configuration options:
 
 - **observable**: set to true to return an Observable
+- **methodName**: an optional name of the cordova plugins method name (if different from wrappers method name)
 - **clearFunction**: an optional name of a method to clear the observable we returned
 - **clearWithArgs**: This can be used if clearFunction is set. Set this to true to call the clearFunction with the same arguments used in the initial function.
 - **sync**: set to true if the method should return the value as-is without wrapping with Observable/Promise

--- a/scripts/build/transformers/methods.ts
+++ b/scripts/build/transformers/methods.ts
@@ -54,7 +54,7 @@ function getMethodBlock(method: ts.MethodDeclaration, decoratorName: string, dec
     default:
       return ts.createCall(ts.createIdentifier(decoratorMethod), undefined, [
         ts.createThis(),
-        ts.createLiteral((method.name as any).text),
+        ts.createLiteral(decoratorArgs?.methodName || (method.name as any).text),
         convertValueToLiteral(decoratorArgs),
         ts.createIdentifier('arguments'),
       ]);

--- a/src/@ionic-native/core/decorators/interfaces.ts
+++ b/src/@ionic-native/core/decorators/interfaces.ts
@@ -34,6 +34,11 @@ export interface PluginConfig {
 export interface CordovaOptions {
   destruct?: boolean;
   /**
+   * If the method-name of the cordova plugin is different from the wrappers one, it can be defined here
+   */
+  methodName?: string;
+
+  /**
    * Set to true if the wrapped method is a sync function
    */
   sync?: boolean;


### PR DESCRIPTION
closes #3557

As i wrote in the linked Issue, this can be very useful.

- `methodName` add to Interface
- add to developer docs
- while creating messageBlock, prefer the given methodName if available