### PR TITLE
feat(AppsFlyer): update to 6.x.x

### DIFF
--- a/src/@ionic-native/plugins/appsflyer/index.ts
+++ b/src/@ionic-native/plugins/appsflyer/index.ts
@@ -94,7 +94,7 @@ export class Appsflyer extends IonicNativePlugin {
    * @param {string} eventName custom event name, is presented in your dashboard
    * @param {AppsflyerEvent} eventValues event details
    */
-  @Cordova({ sync: true })
+  @Cordova()
   logEvent(eventName: string, eventValues: AppsflyerEvent): void {}
 
   /**

--- a/src/@ionic-native/plugins/appsflyer/index.ts
+++ b/src/@ionic-native/plugins/appsflyer/index.ts
@@ -95,7 +95,7 @@ export class Appsflyer extends IonicNativePlugin {
    * @param {AppsflyerEvent} eventValues event details
    */
   @Cordova({ sync: true })
-  trackEvent(eventName: string, eventValues: AppsflyerEvent): void {}
+  logEvent(eventName: string, eventValues: AppsflyerEvent): void {}
 
   /**
    * Setting your own Custom ID enables you to cross-reference your own unique ID with AppsFlyer’s user ID and the other devices’ IDs. This ID is available in AppsFlyer CSV reports along with postbacks APIs for cross-referencing with you internal IDs.
@@ -109,7 +109,7 @@ export class Appsflyer extends IonicNativePlugin {
    * @param {boolean} customerUserId In some extreme cases you might want to shut down all SDK tracking due to legal and privacy compliance. This can be achieved with the isStopTracking API. Once this API is invoked, our SDK will no longer communicate with our servers and stop functioning.
    */
   @Cordova({ sync: true })
-  stopTracking(isStopTracking: boolean): void {}
+  Stop(isStopTracking: boolean): void {}
 
   /**
    * Get the data from Attribution
@@ -120,7 +120,9 @@ export class Appsflyer extends IonicNativePlugin {
     return;
   }
 
+
   /**
+   * @deprecated
    * Enables app uninstall tracking
    * @param {string} token GCM/FCM ProjectNumber
    * @returns {Promise<any>}
@@ -157,7 +159,7 @@ export class Appsflyer extends IonicNativePlugin {
    * @param {boolean} disable Set to true to opt-out user from tracking
    */
   @Cordova({ sync: true })
-  deviceTrackingDisabled(disable: boolean): void {}
+  anonymizeUser(disable: boolean): void {}
 
   /**
    * Set AppsFlyer’s OneLink ID. Setting a valid OneLink ID will result in shortened User Invite links, when one is generated. The OneLink ID can be obtained on the AppsFlyer Dashboard.
@@ -182,7 +184,7 @@ export class Appsflyer extends IonicNativePlugin {
    * @param {string} campaign Promoted Campaign
    */
   @Cordova({ sync: true })
-  trackCrossPromotionImpression(appId: string, campaign: string): void {}
+  logCrossPromotionImpression(appId: string, campaign: string): void {}
 
   /**
    * Use this call to track the click and launch the app store's app page (via Browser)
@@ -191,5 +193,5 @@ export class Appsflyer extends IonicNativePlugin {
    * @param {Object} options Additional Parameters to track
    */
   @Cordova({ sync: true })
-  trackAndOpenStore(appId: string, campaign: string, options: Object): void {}
+  logCrossPromotionAndOpenStore(appId: string, campaign: string, options: Object): void {}
 }


### PR DESCRIPTION
In AppsFlyer Cordova plugin 6.x.x the api was changed from 'track' to 'log'.
Ionic-Native AppsFlyer plugin support only until version 5.4.30