### PR TITLE
feat(sqlite):add androidDatabaseLocation Support

### DIFF
--- a/src/@ionic-native/plugins/sqlite/index.ts
+++ b/src/@ionic-native/plugins/sqlite/index.ts
@@ -24,6 +24,10 @@ export interface SQLiteDatabaseConfig {
    */
   iosDatabaseLocation?: string;
   /**
+  * support arbitrary database location on android with https://github.com/litehelpers/cordova-sqlite-evcore-extbuild-free
+  */
+  androidDatabaseLocation?: string;
+  /**
    * support opening pre-filled databases with https://github.com/litehelpers/cordova-sqlite-ext
    */
   createFromLocation?: number;

--- a/src/@ionic-native/plugins/sqlite/index.ts
+++ b/src/@ionic-native/plugins/sqlite/index.ts
@@ -24,8 +24,8 @@ export interface SQLiteDatabaseConfig {
    */
   iosDatabaseLocation?: string;
   /**
-  * support arbitrary database location on android with https://github.com/litehelpers/cordova-sqlite-evcore-extbuild-free
-  */
+   * support arbitrary database location on android with https://github.com/litehelpers/cordova-sqlite-evcore-extbuild-free
+   */
   androidDatabaseLocation?: string;
   /**
    * support opening pre-filled databases with https://github.com/litehelpers/cordova-sqlite-ext


### PR DESCRIPTION
Current behavior:
Using sqlite plugin with cordova-sqlite-evcore-extbuild-free, it's not possible to use its androidDatabaseLocation feature which enables support for arbitrary database location on android.

The SQLiteDatabaseConfig interface currently don't have a slot for androidDatabaseLocation.

Expected behavior:
Here's the code for existing iosDatabaseLocation :

/**
* iOS Database Location. Example: 'Library'
*/
iosDatabaseLocation?: string;

Here's the code to add to the interface to support androidDatabaseLocation:

/**
* support arbitrary database location on android with https://github.com/litehelpers/cordova-sqlite-evcore-extbuild-free
*/
androidDatabaseLocation?: string;

Steps to reproduce:
When creating a connection using the SQLite.create method, the androidDatabaseLocation is simply not available:

Sqlite.create({name: dbFileName, androidDatabaseLocation: dbPath}) --> unknown property androidDatabaseLocation