### PR TITLE
docs(cordova-plugin-firebase-analytics): Adding instructions for capacitor support on Android.

### DIFF
--- a/src/@ionic-native/plugins/firebase-analytics/index.ts
+++ b/src/@ionic-native/plugins/firebase-analytics/index.ts
@@ -11,6 +11,22 @@ import { Cordova, IonicNativePlugin, Plugin } from '@ionic-native/core';
  *
  * NOTE: on iOS in order to collect demographic, age, gender data etc. you should additionally include AdSupport.framework into your project.
  *
+ * ## Using capacitor?
+ * For Android you'll have to add in __android/app/src/main/AndroidManfiest.xml__ under `<application>`
+ * ```
+ * <meta-data
+ *      tools:replace="android:value"
+ *      android:name="firebase_analytics_collection_enabled"
+ *      android:value="true"/>
+ *
+ * <meta-data
+ *      tools:replace="android:value"
+ *      android:name="google_analytics_automatic_screen_reporting_enabled"
+ *      android:value="false"/>
+ * ```
+ *
+ * And in the same file, you'll have to add `xmlns:tools="http://schemas.android.com/tools"` to your _manifest_ tag.
+ *
  * @usage
  * ```typescript
  * import { FirebaseAnalytics } from '@ionic-native/firebase-analytics/ngx';


### PR DESCRIPTION
Adding instructions for firebase analytics capacitor support on Android, because the plugin require cordova variables.