### PR TITLE
feat(firebase-dynamic-links): add missing method

### DIFF
--- a/src/@ionic-native/plugins/firebase-dynamic-links/index.ts
+++ b/src/@ionic-native/plugins/firebase-dynamic-links/index.ts
@@ -98,6 +98,17 @@ export interface ILinkOptions {
 @Injectable()
 export class FirebaseDynamicLinks extends IonicNativePlugin {
   /**
+   * Determines if the app has a pending dynamic link and provides access to the dynamic link parameters.
+   * @return {Promise<IDynamicLink>} Returns a promise
+   */
+  @Cordova({
+    otherPromise: true,
+  })
+  getDynamicLink(): Promise<IDynamicLink> {
+    return;
+  }
+
+  /**
    * Registers callback that is triggered on each dynamic link click.
    * @return {Observable<IDynamicLink>} Returns an observable
    */


### PR DESCRIPTION
Added Typescript definition for the recently added [`getDynamicLink()`](https://github.com/chemerisuk/cordova-plugin-firebase-dynamiclinks#getdynamiclink) method.