### PR TITLE
feat(wonderpush): remove isReady method.

### DIFF
--- a/src/@ionic-native/plugins/wonderpush/index.ts
+++ b/src/@ionic-native/plugins/wonderpush/index.ts
@@ -240,17 +240,6 @@ export class WonderPush extends IonicNativePlugin {
   }
 
   /**
-   * Whether the SDK is ready to operate.
-   *
-   * The SDK is ready when it is initialized and has fetched an access token.
-   * @returns {Promise<any>}
-   */
-  @Cordova()
-  isReady(): Promise<boolean> {
-    return;
-  }
-
-  /**
    * Controls native SDK logging.
    * @param {boolean} enabled - Whether to enable logs.
    * @returns {Promise<any>}


### PR DESCRIPTION
We've upgraded our Cordova plugin to a major version and this method is no longer available.