### PR TITLE
feat(in-app-purchase-2): add redeem() for opening redeem code dialog [iOS]

### DIFF
--- a/src/@ionic-native/plugins/in-app-purchase-2/index.ts
+++ b/src/@ionic-native/plugins/in-app-purchase-2/index.ts
@@ -874,4 +874,8 @@ export class InAppPurchase2 extends IonicNativePlugin {
   /** Opens the Manage Subscription page (AppStore, Play, Microsoft, ...). */
   @Cordova({ sync: true })
   manageSubscriptions(): void {}
+
+  /** Opens the Code Redemption Sheet on iOS. (AppStore). */
+  @Cordova({ sync: true })
+  redeem(): void {}
 }


### PR DESCRIPTION
This new iOS App Store-feature was added in j3k0's cordova-plugin-purchase version 10.5.0, released 8 days ago.

More info on offer codes: [https://developer.apple.com/app-store/subscriptions/#offer-codes](https://developer.apple.com/app-store/subscriptions/#offer-codes)