### PR TITLE
fix(launchnavigator): make appSelection accessible

### DIFF
--- a/src/@ionic-native/plugins/launch-navigator/index.ts
+++ b/src/@ionic-native/plugins/launch-navigator/index.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { Cordova, IonicNativePlugin, Plugin } from '@ionic-native/core';
+import { Cordova, CordovaProperty, IonicNativePlugin, Plugin } from '@ionic-native/core';
 
 export interface PromptsOptions {
   /**
@@ -173,6 +173,11 @@ export interface LaunchNavigatorOptions {
   enableGeolocation?: boolean;
 
   /**
+   * If true, and input location type(s) doesn't match those required by the app, use geocoding to obtain the address/coords as required. Defaults to true.
+   */
+  enableGeocoding?: boolean;
+
+  /**
    * options related to the default native actionsheet picker which enables user to select which navigation app to launch if `app` is not specified.
    */
   appSelection?: AppSelectionOptions;
@@ -297,6 +302,8 @@ export class LaunchNavigator extends IonicNativePlugin {
     BICYCLING: 'bicycling',
     TRANSIT: 'transit',
   };
+
+  @CordovaProperty()
   appSelection: AppSelection;
 
   /**


### PR DESCRIPTION
Without the decorator the property is not working when calling `this.launchNavigator.appSelection.userChoice` for example.