### PR TITLE
feat(firebase-authentication): add signInWithApple method

### DIFF
--- a/src/@ionic-native/plugins/firebase-authentication/index.ts
+++ b/src/@ionic-native/plugins/firebase-authentication/index.ts
@@ -127,6 +127,16 @@ export class FirebaseAuthentication extends IonicNativePlugin {
   }
 
   /**
+   * Uses Apples's idToken and rawNonce (optional) to sign-in into firebase account. In order to retrieve those tokens follow instructions for Android and iOS
+   * @param idToken ID Token
+   * @param rawNonce Access Token
+   */
+  @Cordova({ sync: true })
+  signInWithApple(identityToken: string, rawNonce?: string): Promise<any> {
+    return;
+  }
+
+  /**
    * Uses Facebook's accessToken to sign-in into firebase account. In order to retrieve those tokens follow instructions for Android and iOS.
    * @param accessToken Access Token
    */


### PR DESCRIPTION
Adding missing signInWithApple method to the firebase-authentication plugin.

The cordova plugin has this method but the ionic native wrapper doesn't.

Ref. https://github.com/chemerisuk/cordova-plugin-firebase-authentication#signinwithappleidtoken-rawnonce