### PR TITLE
feat(purchases): bump cordova-plugin-purchases from 1.3.2 to 2.0.0

### DIFF
--- a/src/@ionic-native/plugins/purchases/index.ts
+++ b/src/@ionic-native/plugins/purchases/index.ts
@@ -207,7 +207,7 @@ export enum INTRO_ELIGIBILITY_STATUS {
  */
 @Plugin({
   pluginName: 'Purchases',
-  plugin: 'cordova-plugin-purchases@1.3.2',
+  plugin: 'cordova-plugin-purchases@2.0.0',
   pluginRef: 'Purchases', // the variable reference to call the plugin, example: navigator.geolocation
   repo: 'https://github.com/RevenueCat/cordova-plugin-purchases', // the github repository URL for the plugin
   platforms: ['Android', 'iOS'], // Array of platforms supported, example: ['Android', 'iOS']
@@ -317,31 +317,6 @@ export class Purchases extends IonicNativePlugin {
    * @property {string} productIdentifier - The product identifier that has been purchased
    * @property {PurchaserInfo} purchaserInfo - The new PurchaserInfo after the successful purchase
    */
-
-  /**
-   * Make a purchase
-   *
-   * @deprecated Use purchaseProduct instead.
-   *
-   * @param {string} productIdentifier The product identifier of the product you want to purchase.
-   * @param {string?} oldSKU Optional sku you wish to upgrade from.
-   * @param {PURCHASE_TYPE} type Optional type of product, can be inapp or subs. Subs by default
-   *
-   * @return {Promise<MakePurchaseResponse>} A [PurchasesError] is triggered after an error or when the user cancels the purchase.
-   * If user cancelled, userCancelled will be true
-   */
-  @Cordova({
-    successIndex: 1,
-    errorIndex: 2,
-    observable: true,
-  })
-  makePurchase(
-    productIdentifier: string,
-    oldSKU?: string | null,
-    type: PURCHASE_TYPE = PURCHASE_TYPE.SUBS
-  ): Promise<{ productIdentifier: string; purchaserInfo: PurchaserInfo }> {
-    return;
-  }
 
   /**
    * Make a purchase
@@ -479,10 +454,18 @@ export class Purchases extends IonicNativePlugin {
    * This method will send all the purchases to the RevenueCat backend. Call this when using your own implementation
    * for subscriptions anytime a sync is needed, like after a successful purchase.
    *
-   * @warning This function should only be called if you're not calling makePurchase.
+   * @warning This function should only be called if you're not calling purchaseProduct.
    */
   @Cordova({ sync: true })
   syncPurchases(): void {}
+
+  /**
+   * iOS only. Presents a code redemption sheet, useful for redeeming offer codes
+   * Refer to https://docs.revenuecat.com/docs/ios-subscription-offers#offer-codes for more information on how
+   * to configure and use offer codes.
+   */
+  @Cordova({ sync: true })
+  presentCodeRedemptionSheet(): void {}
 
   /**
    * Enable automatic collection of Apple Search Ads attribution. Disabled by default.


### PR DESCRIPTION
### 2.0.0

- remove deprecated `makePurchase`, replaced by `purchaseProduct`
 - iOS: 
     - add new method, `syncPurchases`, that enables syncing the purchases in the local receipt with the backend without risking a password prompt. The method was already available on Android.
     - add a new method, `presentCodeRedemptionSheet`, for offer codes redemption.
- Bump `purchases-hybrid-common` to 1.5.0 [Changelog here](https://github.com/RevenueCat/purchases-hybrid-common/releases/1.5.0)
- Bump `purchases-ios` to 3.9.2 [Changelog here](https://github.com/RevenueCat/purchases-ios/releases/3.9.2)
- Bump `purchases-android` to 4.0.1 [Changelog here](https://github.com/RevenueCat/purchases-android/releases/4.0.1)
