### PR TITLE
feat(facebook): add setAutoLogAppEventsEnabled method

### DIFF
--- a/src/@ionic-native/plugins/facebook/index.ts
+++ b/src/@ionic-native/plugins/facebook/index.ts
@@ -287,6 +287,19 @@ export class Facebook extends IonicNativePlugin {
   }
 
   /**
+   * Enable or disable the auto log app event feature - https://developers.facebook.com/docs/app-events/gdpr-compliance/
+   *
+   * @param {boolean}  enabled value to be set
+   */
+  @Cordova({
+    successIndex: 1,
+    errorIndex: 2,
+  })
+  setAutoLogAppEventsEnabled(enabled: boolean): Promise<void> {
+    return;
+  }
+
+  /**
    * Log a purchase. For more information see the Events section above.
    *
    * @param {number}  value Value of the purchase.


### PR DESCRIPTION
With the merge of #3603 and my [PR](https://github.com/cordova-plugin-facebook-connect/cordova-plugin-facebook-connect/pull/8) to that new fork, the plugin now supports Facebooks GDPR Compliance.