### PR TITLE
fix(bluetooth-le): add missing status type value and add missing (opt…

### DIFF
--- a/src/@ionic-native/plugins/bluetooth-le/index.ts
+++ b/src/@ionic-native/plugins/bluetooth-le/index.ts
@@ -40,7 +40,8 @@ export type Status =
   | 'advertisingStarted'
   | 'advertisingStopped'
   | 'responded'
-  | 'notified';
+  | 'notified'
+  | 'notificationSent';
 
 /** Available connection priorities */
 export type ConnectionPriority = 'low' | 'balanced' | 'high';
@@ -88,6 +89,8 @@ export interface NotifyParams {
   characteristic: string;
   /** Base64 encoded string, number or string */
   value: string;
+  /** Android only: address of the device the notification should be sent to. */
+  address?: string;
 }
 
 export interface RespondParams {


### PR DESCRIPTION
…ional) address property to NotifyParams interface.

The status type value missing here (notificationSent) was added to the cordova plugin repo 8 months ago.
The optional address property (only used on android) of the NotifyParams interface is also missing in the cordova plugin repo but mentioned in the Documentation/Readme of the plugin.