### PR TITLE
feat(in-app-purchase-2): adds typings for transaction

### DIFF
--- a/src/@ionic-native/plugins/in-app-purchase-2/index.ts
+++ b/src/@ionic-native/plugins/in-app-purchase-2/index.ts
@@ -81,7 +81,7 @@ export interface IAPProduct {
 
   additionalData?: any;
 
-  transaction?: any;
+  transaction?: PlayStoreReceipt | AppStoreReceipt;
 
   /**
    * Call `product.finish()` to confirm to the store that an approved order has been delivered.
@@ -189,6 +189,23 @@ export interface IAPProductEvents {
   /** Called when content download has successfully completed. */
   downloaded: (callback: IAPQueryCallback) => IAPProductEvents;
 }
+
+export type PlayStoreReceipt = {
+  id: string;
+  purchaseState: number;
+  purchaseToken: string;
+  receipt: string;
+  signature: string;
+  type: "android-playstore";
+};
+
+export type AppStoreReceipt = {
+  id: string;
+  appStoreReceipt: string;
+  original_transaction_id: string;
+  type: "ios-appstore";
+};
+
 
 /**
  * @hidden


### PR DESCRIPTION
The `any` in the transaction is quite annoying that's why I looked into the docs of the corresponding corodva-plugin and found the typings for it: https://github.com/j3k0/cordova-plugin-purchase/blob/d5589af8c449ff87428b9ae8a59abacd839bdaaf/src/js/validator.js#L336

I can also confirm the correctness of the typings on my iOS and Android device.