### PR TITLE
feat(network): declare connection enum with strings

### DIFF
--- a/src/@ionic-native/plugins/network/index.ts
+++ b/src/@ionic-native/plugins/network/index.ts
@@ -5,14 +5,14 @@ import { Observable, merge } from 'rxjs';
 declare const navigator: any;
 
 export enum Connection {
-  UNKNOWN = 0,
-  ETHERNET,
-  WIFI,
-  CELL_2G,
-  CELL_3G,
-  CELL_4G,
-  CELL,
-  NONE,
+  UNKNOWN = 'unknown',
+  ETHERNET = 'ethernet',
+  WIFI = 'wifi',
+  CELL_2G = '2g',
+  CELL_3G = '3g',
+  CELL_4G = '4g',
+  CELL = 'cellular',
+  NONE = 'none',
 }
 
 /**


### PR DESCRIPTION
This enum was introduced in #2754 but it is declared with numbers, which may cause issues when doing something like:

```ts
this.network.type === Connection.NONE
```

Typescript will complain that `this.network.type` is a string and `Connection.NONE` is a number.