### PR TITLE
feat(purchases): bump cordova-plugin-purchases from 2.0.0 to 2.1.1

### DIFF
--- a/src/@ionic-native/plugins/purchases/index.ts
+++ b/src/@ionic-native/plugins/purchases/index.ts
@@ -207,7 +207,7 @@ export enum INTRO_ELIGIBILITY_STATUS {
  */
 @Plugin({
   pluginName: 'Purchases',
-  plugin: 'cordova-plugin-purchases@2.1.0',
+  plugin: 'cordova-plugin-purchases@2.1.1',
   pluginRef: 'Purchases', // the variable reference to call the plugin, example: navigator.geolocation
   repo: 'https://github.com/RevenueCat/cordova-plugin-purchases', // the github repository URL for the plugin
   platforms: ['Android', 'iOS'], // Array of platforms supported, example: ['Android', 'iOS']

--- a/src/@ionic-native/plugins/purchases/index.ts
+++ b/src/@ionic-native/plugins/purchases/index.ts
@@ -207,7 +207,7 @@ export enum INTRO_ELIGIBILITY_STATUS {
  */
 @Plugin({
   pluginName: 'Purchases',
-  plugin: 'cordova-plugin-purchases@2.0.0',
+  plugin: 'cordova-plugin-purchases@2.1.0',
   pluginRef: 'Purchases', // the variable reference to call the plugin, example: navigator.geolocation
   repo: 'https://github.com/RevenueCat/cordova-plugin-purchases', // the github repository URL for the plugin
   platforms: ['Android', 'iOS'], // Array of platforms supported, example: ['Android', 'iOS']
@@ -466,6 +466,14 @@ export class Purchases extends IonicNativePlugin {
    */
   @Cordova({ sync: true })
   presentCodeRedemptionSheet(): void {}
+
+  /**
+   * iOS only.
+   * @param {Boolean} enabled Set this property to true *only* when testing the ask-to-buy / SCA purchases flow.
+   * More information: http://errors.rev.cat/ask-to-buy
+   */
+  @Cordova({ sync: true })
+  setSimulatesAskToBuyInSandbox(enabled: boolean): void {}
 
   /**
    * Enable automatic collection of Apple Search Ads attribution. Disabled by default.


### PR DESCRIPTION
## 2.1.1

- iOS: 
    - Added a new method `setSimulatesAskToBuyInSandbox`, that allows developers to test deferred purchases easily.
- Bumped purchases-hybrid-common to 1.6.2 [Changelog here](https://github.com/RevenueCat/purchases-hybrid-common/releases/1.6.2)
- Bumped purchases-ios to 3.10.7 [Changelog here](https://github.com/RevenueCat/purchases-ios/releases/3.10.7)
- Bumped purchases-android to 4.0.5 [Changelog here](https://github.com/RevenueCat/purchases-hybrid-common/releases/4.0.5)
    https://github.com/RevenueCat/cordova-plugin-purchases/pull/79