### PR TITLE
fix(network): onChange no longer causes error

### DIFF
--- a/src/@ionic-native/plugins/network/index.ts
+++ b/src/@ionic-native/plugins/network/index.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@angular/core';
 import { Cordova, CordovaCheck, CordovaProperty, IonicNativePlugin, Plugin } from '@ionic-native/core';
 import { Observable, merge } from 'rxjs';
+import { mapTo } from 'rxjs/operators';
 
 declare const navigator: any;
 
@@ -99,7 +100,10 @@ export class Network extends IonicNativePlugin {
    */
   @CordovaCheck()
   onChange(): Observable<'connected' | 'disconnected'> {
-    return merge(this.onConnect().pipe(mapTo('connected')), this.onDisconnect().pipe(mapTo('disconnected'));
+    return merge(
+      this.onConnect().pipe(mapTo('connected')),
+      this.onDisconnect().pipe(mapTo('disconnected')) as Observable<'disconnected'>
+    );
   }
 
   /**


### PR DESCRIPTION
After PR #3608 the Network onChange Method throws `mapTo is not defined`.

I imported it correctly and fixed the typing.

closes #3649