### PR TITLE
feat(ble): update with setPin to allow set device pin

### DIFF
--- a/src/@ionic-native/plugins/ble/index.ts
+++ b/src/@ionic-native/plugins/ble/index.ts
@@ -264,6 +264,27 @@ export class BLE extends IonicNativePlugin {
   }
 
   /**
+   * Set device pin.
+   * @usage
+   * ```
+   *   BLE.setPin(pin).subscribe(success => {
+   *     console.log(success);
+   *   },
+   *   failure => {
+   *     console.log('failure');
+   *   });
+   * ```
+   * @param {string} pin Pin of the device as a string
+   * @return {Observable<any>} Returns an Observable that notifies of success/failure.
+   */
+  @Cordova({
+    observable: true,
+  })
+  setPin(pin: string): Observable<any> {
+    return;
+  }
+
+  /**
    * Connect to a peripheral.
    * @usage
    * ```


### PR DESCRIPTION
Fixes: #3620 

This PR will add the function which allow to set the device pin. 
Set device pin is supported in latest version of "don/cordova-plugin-ble-central".

`ble.setPin(pin, [success], [failure]);`

https://github.com/don/cordova-plugin-ble-central#setpin