### PR TITLE
fix(android-full-screen): add correct return type

### DIFF
--- a/src/@ionic-native/plugins/android-full-screen/index.ts
+++ b/src/@ionic-native/plugins/android-full-screen/index.ts
@@ -71,7 +71,7 @@ export class AndroidFullScreen extends IonicNativePlugin {
    * @return {Promise<void>}
    */
   @Cordova()
-  isImmersiveModeSupported(): Promise<void> {
+  isImmersiveModeSupported(): Promise<boolean> {
     return;
   }
 


### PR DESCRIPTION
`isImmersiveModeSupported` returns a boolean in the [android code](https://github.com/mesmotronic/cordova-plugin-fullscreen/blob/master/src/android/com/mesmotronic/plugins/FullScreenPlugin.java#L129), so it also should here.