### PR TITLE
fix(smartlook): fix SmartlookResetSession.resetUser type to boolean

### DIFF
--- a/src/@ionic-native/plugins/smartlook/index.ts
+++ b/src/@ionic-native/plugins/smartlook/index.ts
@@ -52,9 +52,9 @@ export class SmartlookSetupConfig {
 }
 
 export class SmartlookResetSession {
-  private resetUser: string;
+  private resetUser: boolean;
 
-  constructor(resetUser: string) {
+  constructor(resetUser: boolean) {
     this.resetUser = resetUser;
   }
 }


### PR DESCRIPTION
There was wrongly used `string` type where the underlaying cordova code expects `boolean`.