### PR TITLE
feat(firebase-authentication) add getCurrentUser() definition

### DIFF
--- a/src/@ionic-native/plugins/firebase-authentication/index.ts
+++ b/src/@ionic-native/plugins/firebase-authentication/index.ts
@@ -34,6 +34,17 @@ import { Observable } from 'rxjs';
 })
 @Injectable()
 export class FirebaseAuthentication extends IonicNativePlugin {
+  
+  
+  /**
+   * Returns the current user logged in Firebase service
+   * @return {Promise<any>} Returns the user info
+   */
+  @Cordova({ sync: true })
+  getCurrentUser(): Promise<any> {
+    return;
+  }
+  
   /**
    * Returns a JWT token used to identify the user to a Firebase service.
    * @param forceRefresh {boolean} Force Refresh


### PR DESCRIPTION
This definition is missing, given plugin documentation : 

https://github.com/chemerisuk/cordova-plugin-firebase-authentication#getcurrentuser