### PR TITLE
fix(test): Cannot find module 'lodash.sortby'

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9546,6 +9546,12 @@
       "integrity": "sha1-dx7Hg540c9nEzeKLGTlMNWL09tM=",
       "dev": true
     },
+    "lodash.sortby": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
+      "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
+      "dev": true
+    },
     "lodash.template": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-4.5.0.tgz",

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "jest": "^27.0.6",
     "lint-staged": "^11.0.0",
     "lodash": "^4.17.21",
+    "lodash.sortby": "^4.7.0",
     "minimist": "^1.2.5",
     "natives": "^1.1.6",
     "prettier": "^2.3.2",


### PR DESCRIPTION
`> npm run test
> jest

 FAIL  src/@ionic-native/core/decorators/common.spec.ts
  ● Test suite failed to run

    Cannot find module 'lodash.sortby'
    Require stack:
    - /Users/***/ionic-native/node_modules/whatwg-url/dist/URLSearchParams-impl.js
    - /Users/***/ionic-native/node_modules/whatwg-url/dist/URLSearchParams.js
    - /Users/***/ionic-native/node_modules/whatwg-url/dist/URL-impl.js
    - /Users/***/ionic-native/node_modules/whatwg-url/dist/URL.js
    - /Users/***/ionic-native/node_modules/whatwg-url/webidl2js-wrapper.js
    - /Users/***/ionic-native/node_modules/whatwg-url/index.js
    - /Users/***/ionic-native/node_modules/jsdom/lib/api.js
    - /Users/***/node_modules/jest-environment-jsdom/build/index.js
    - /Users/***/ionic-native/node_modules/jest-util/build/requireOrImportModule.js
    - /Users/***/ionic-native/node_modules/jest-util/build/index.js
    - /Users/***/ionic-native/node_modules/@jest/core/build/cli/index.js
    - /Users/***/ionic-native/node_modules/@jest/core/build/jest.js
    - /Users/***/ionic-native/node_modules/jest/node_modules/jest-cli/build/cli/index.js
    - /Users/***/ionic-native/node_modules/jest/node_modules/jest-cli/bin/jest.js
    - /Users/***/ionic-native/node_modules/jest/bin/jest.js

      at Object.<anonymous> (node_modules/whatwg-url/dist/URLSearchParams-impl.js:2:22)

Test Suites: 1 failed, 1 total
Tests:       0 total
Snapshots:   0 total
Time:        0.158 s, estimated 4 s
Ran all test suites.
npm ERR! Test failed.  See above for more details.
`