### PR TITLE
fix(purchases): remove static for logIn, logOut methods

### DIFF
--- a/src/@ionic-native/plugins/purchases/index.ts
+++ b/src/@ionic-native/plugins/purchases/index.ts
@@ -430,7 +430,7 @@ export class Purchases extends IonicNativePlugin {
    * whether the user has just been created for the first time in the RevenueCat backend.
    */
   @Cordova()
-  static logIn(appUserID: string): Promise<LogInResult> {
+  logIn(appUserID: string): Promise<LogInResult> {
     return;
   }
 
@@ -440,7 +440,7 @@ export class Purchases extends IonicNativePlugin {
    * @return {Promise<PurchaserInfo>} new purchaser info after resetting.
    */
   @Cordova()
-  static logOut(): Promise<PurchaserInfo> {
+  logOut(): Promise<PurchaserInfo> {
     return;
   }
 


### PR DESCRIPTION
Purchases plugin is not working in my ionic project with static method logIn, logOut
that methods will return undefined so I removed static of logIn, logOut methods.

This code must be reviewed by revenuecat developers before marge.