### PR TITLE
fix(ibeacon): undefined locationManager

### DIFF
--- a/src/@ionic-native/plugins/ibeacon/index.ts
+++ b/src/@ionic-native/plugins/ibeacon/index.ts
@@ -293,7 +293,7 @@ export class IBeacon extends IonicNativePlugin {
    */
   @CordovaCheck({ sync: true })
   Delegate(): IBeaconDelegate {
-    const delegate = new window.cordova.plugins.locationManager.Delegate();
+    const delegate = new cordova.plugins.locationManager.Delegate();
 
     delegate.didChangeAuthorizationStatus = (pluginResult?: IBeaconPluginResult) => {
       return new Observable<IBeaconPluginResult>((observer: any) => {
@@ -358,7 +358,7 @@ export class IBeacon extends IonicNativePlugin {
       });
     };
 
-    window.cordova.plugins.locationManager.setDelegate(delegate);
+    cordova.plugins.locationManager.setDelegate(delegate);
     return delegate;
   }
 
@@ -382,7 +382,7 @@ export class IBeacon extends IonicNativePlugin {
     minor?: number,
     notifyEntryStateOnDisplay?: boolean
   ): BeaconRegion {
-    return new window.cordova.plugins.locationManager.BeaconRegion(
+    return new cordova.plugins.locationManager.BeaconRegion(
       identifer,
       uuid,
       major,


### PR DESCRIPTION
Copy of  #3505
Same issue in Ionic 4 -> https://github.com/ionic-team/ionic-native/issues/2631

Change some cordova.plugins calls to window.cordova.plugins to
prevent 'Cannot read property 'locationManager' of undefined'