### PR TITLE
fix(barcode-scanner): add `saveHistory` option

### DIFF
--- a/src/@ionic-native/plugins/barcode-scanner/index.ts
+++ b/src/@ionic-native/plugins/barcode-scanner/index.ts
@@ -46,6 +46,11 @@ export interface BarcodeScannerOptions {
    * Launch with the torch switched on (if available). Supported on Android only.
    */
   torchOn?: boolean;
+  
+  /**
+   * Save scan history. Defaults to `false`. Supported on Android only.
+   */
+  saveHistory?: boolean;
 
   /**
    * Display scanned text for X ms. 0 suppresses it entirely, default 1500. Supported on Android only.


### PR DESCRIPTION
Adds the missing Android-only `saveHistory` option.

https://github.com/phonegap/phonegap-plugin-barcodescanner#using-the-plugin
https://github.com/phonegap/phonegap-plugin-barcodescanner/blob/v8.1.0/src/android/com/phonegap/plugins/barcodescanner/BarcodeScanner.java#L52